### PR TITLE
feat: add BroadcastCancelAsync method

### DIFF
--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -789,6 +789,14 @@ public interface IResend
     Task<ResendResponse> BroadcastScheduleAsync( Guid broadcastId, DateTime scheduleFor, CancellationToken cancellationToken = default );
 
     /// <summary>
+    /// Cancels a queued or scheduled broadcast.
+    /// </summary>
+    /// <param name="broadcastId">Broadcast identifier.</param>
+    /// <param name="cancellationToken">Cancelation token.</param>
+    /// <returns>Response.</returns>
+    Task<ResendResponse> BroadcastCancelAsync( Guid broadcastId, CancellationToken cancellationToken = default );
+
+    /// <summary>
     /// Lists all broadcasts.
     /// </summary>
     /// <param name="cancellationToken">Cancelation token.</param>

--- a/src/Resend/ResendClient.cs
+++ b/src/Resend/ResendClient.cs
@@ -432,6 +432,16 @@ public partial class ResendClient : IResend
 
 
     /// <inheritdoc/>
+    public Task<ResendResponse> BroadcastCancelAsync( Guid broadcastId, CancellationToken cancellationToken = default )
+    {
+        var path = $"/broadcasts/{broadcastId}/cancel";
+        var req = new HttpRequestMessage( HttpMethod.Post, path );
+
+        return Execute( req, cancellationToken );
+    }
+
+
+    /// <inheritdoc/>
     public Task<ResendResponse<List<Broadcast>>> BroadcastListAsync( CancellationToken cancellationToken = default )
     {
         var path = $"/broadcasts";

--- a/tests/Resend.Tests/ResendClientTests.cs
+++ b/tests/Resend.Tests/ResendClientTests.cs
@@ -393,6 +393,16 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
 
     /// <summary/>
     [Fact]
+    public async Task BroadcastCancel()
+    {
+        var resp = await _resend.BroadcastCancelAsync( Guid.NewGuid() );
+
+        Assert.NotNull( resp );
+    }
+
+
+    /// <summary/>
+    [Fact]
     public async Task BroadcastList()
     {
         var resp = await _resend.BroadcastListAsync();

--- a/tools/Resend.ApiServer/Controllers/BroadcastController.cs
+++ b/tools/Resend.ApiServer/Controllers/BroadcastController.cs
@@ -80,6 +80,17 @@ public class BroadcastController : ControllerBase
 
 
     /// <summary />
+    [HttpPost]
+    [Route( "broadcasts/{broadcastId}/cancel" )]
+    public ActionResult BroadcastCancel( [FromRoute] Guid broadcastId )
+    {
+        _logger.LogDebug( "BroadcastCancel" );
+
+        return Ok();
+    }
+
+
+    /// <summary />
     [HttpDelete]
     [Route( "broadcasts/{broadcastId}" )]
     public ActionResult BroadcastDelete( [FromRoute] Guid broadcastId )

--- a/tools/Resend.Cli/Broadcast/BroadcastCancelCommand.cs
+++ b/tools/Resend.Cli/Broadcast/BroadcastCancelCommand.cs
@@ -1,0 +1,33 @@
+using McMaster.Extensions.CommandLineUtils;
+using System.ComponentModel.DataAnnotations;
+
+namespace Resend.Cli.Broadcast;
+
+/// <summary />
+[Command( "cancel", Description = "Cancels a queued or scheduled broadcast" )]
+public class BroadcastCancelCommand
+{
+    private readonly IResend _resend;
+
+
+    /// <summary />
+    [Argument( 0, Description = "Broadcast identifier" )]
+    [Required]
+    public Guid? BroadcastId { get; set; }
+
+
+    /// <summary />
+    public BroadcastCancelCommand( IResend resend )
+    {
+        _resend = resend;
+    }
+
+
+    /// <summary />
+    public async Task<int> OnExecuteAsync()
+    {
+        await _resend.BroadcastCancelAsync( this.BroadcastId!.Value );
+
+        return 0;
+    }
+}

--- a/tools/Resend.Cli/BroadcastCommand.cs
+++ b/tools/Resend.Cli/BroadcastCommand.cs
@@ -5,6 +5,7 @@ namespace Resend.Cli;
 /// <summary />
 [Command( "broadcast", Description = "Broadcast management" )]
 [Subcommand( typeof( Broadcast.BroadcastAddCommand ))]
+[Subcommand( typeof( Broadcast.BroadcastCancelCommand ) )]
 [Subcommand( typeof( Broadcast.BroadcastDeleteCommand ) )]
 [Subcommand( typeof( Broadcast.BroadcastListCommand ) )]
 [Subcommand( typeof( Broadcast.BroadcastRetrieveCommand ))]


### PR DESCRIPTION
## Summary
- Adds `IResend.BroadcastCancelAsync(broadcastId)`, calling `POST /broadcasts/:id/cancel` to cancel a queued or scheduled broadcast, mirroring `EmailCancelAsync`'s shape (no body).
- Adds the `resend broadcast cancel <id>` CLI subcommand, matching the existing `broadcast delete`/`broadcast send` commands.
- Adds a matching route to the fake `Resend.ApiServer` test server and a `BroadcastCancel` test in `ResendClientTests`.

Part of the broadcast cancel rollout: resend/resend-monorepo#8126, resend/resend-openapi#85, resend/resend-node#1059, resend/resend-docs#1722, resend/resend-go#144, resend/resend-java#122, resend/resend-php#135, resend/resend-python#250, resend/resend-ruby#216, resend/resend-rust#91.

## Test plan
- [x] `dotnet test tests/Resend.Tests` — 8/8 broadcast tests passing, including new `BroadcastCancel`
- [x] `dotnet build resend-dotnet.sln -warnaserror:CS1591` (full 18-project solution, including CLI) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds broadcast cancel support so users can stop a queued or scheduled broadcast before it sends. Includes a new client method and a matching CLI command.

- New Features
  - Added `IResend.BroadcastCancelAsync(broadcastId)` calling POST `/broadcasts/:id/cancel` (no body), mirroring `EmailCancelAsync`.
  - Added CLI command: `resend broadcast cancel <id>`.
  - Added fake server route and a `BroadcastCancel` test.

<sup>Written for commit 244e833287b3cd8977459e64c9722cb3db6057cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

