### PR TITLE
feat(automations): duplicate endpoint

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>0.9.0</Version>
+    <Version>0.10.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -1247,6 +1247,15 @@ public interface IResend
     Task<ResendResponse<PaginatedResult<AutomationSummary>>> AutomationListAsync( AutomationListQuery? query = null, CancellationToken cancellationToken = default );
 
     /// <summary>
+    /// Duplicates an automation.
+    /// </summary>
+    /// <param name="automationId">Automation identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>New automation identifier.</returns>
+    /// <see href="https://resend.com/docs/api-reference/automations/duplicate-automation"/>
+    Task<ResendResponse<Guid>> AutomationDuplicateAsync( Guid automationId, CancellationToken cancellationToken = default );
+
+    /// <summary>
     /// Stops a running automation (sets status to <c>disabled</c>).
     /// </summary>
     /// <param name="automationId">Automation identifier.</param>

--- a/src/Resend/ResendClient.Automations.cs
+++ b/src/Resend/ResendClient.Automations.cs
@@ -67,6 +67,15 @@ public partial class ResendClient
 
 
     /// <inheritdoc />
+    public Task<ResendResponse<Guid>> AutomationDuplicateAsync( Guid automationId, CancellationToken cancellationToken = default )
+    {
+        var req = new HttpRequestMessage( HttpMethod.Post, $"/automations/{automationId}/duplicate" );
+
+        return Execute<ObjectId, Guid>( req, ( x ) => x.Id, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
     public Task<ResendResponse<AutomationStopResult>> AutomationStopAsync( Guid automationId, CancellationToken cancellationToken = default )
     {
         var req = new HttpRequestMessage( HttpMethod.Post, $"/automations/{automationId}/stop" );

--- a/tests/Resend.Tests/ResendClientTests.Automations.cs
+++ b/tests/Resend.Tests/ResendClientTests.Automations.cs
@@ -97,6 +97,20 @@ public partial class ResendClientTests
 
     /// <summary/>
     [Fact]
+    public async Task AutomationDuplicate()
+    {
+        var id = Guid.NewGuid();
+
+        var resp = await _resend.AutomationDuplicateAsync( id );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotEqual( Guid.Empty, resp.Content );
+    }
+
+
+    /// <summary/>
+    [Fact]
     public async Task AutomationStop()
     {
         var id = Guid.NewGuid();

--- a/tools/Resend.ApiServer/Controllers/AutomationController.cs
+++ b/tools/Resend.ApiServer/Controllers/AutomationController.cs
@@ -138,6 +138,21 @@ public class AutomationController : ControllerBase
 
     /// <summary />
     [HttpPost]
+    [Route( "automations/{id}/duplicate" )]
+    public ObjectId AutomationDuplicate( [FromRoute] Guid id )
+    {
+        _logger.LogDebug( "AutomationDuplicate" );
+
+        return new ObjectId()
+        {
+            Object = "automation",
+            Id = Guid.NewGuid(),
+        };
+    }
+
+
+    /// <summary />
+    [HttpPost]
     [Route( "automations/{id}/stop" )]
     public AutomationStopResult AutomationStop( [FromRoute] Guid id )
     {


### PR DESCRIPTION
Adds `AutomationDuplicateAsync(automationId)` for `POST /automations/{id}/duplicate`, returning the new automation identifier.

Resolves DEV-1712. Mirrors the existing `AutomationStopAsync`/`AutomationCreateAsync` patterns and resend-node https://github.com/resend/resend-node/pull/1071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automation duplication to the .NET SDK so clients can clone existing automations. Previously duplication wasn’t available; now `AutomationDuplicateAsync(Guid)` posts to `/automations/{id}/duplicate` and returns the new automation ID. Supports DEV-1712.

- Adds `AutomationDuplicateAsync(Guid, CancellationToken)` to `IResend` and implements it in `ResendClient`, mapping `ObjectId.Id` to `Guid`.
- Adds test `AutomationDuplicate` and a local API stub for `automations/{id}/duplicate`.
- Bumps fallback version in `Directory.Build.props` to `0.10.0`.
- No breaking changes; existing automations APIs are unaffected.

<sup>Written for commit 101da2e2e511a78137138883d234ea02b7c4ab0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

