### PR TITLE
fix(contacts): properties response shape

### DIFF
--- a/src/Resend/Contact.cs
+++ b/src/Resend/Contact.cs
@@ -52,5 +52,5 @@ public class Contact
     /// </summary>
     [JsonPropertyName( "properties" )]
     [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
-    public Dictionary<string,string>? Properties { get; set; }
+    public Dictionary<string, ContactPropertyValue>? Properties { get; set; }
 }

--- a/src/Resend/ContactPropertyType.cs
+++ b/src/Resend/ContactPropertyType.cs
@@ -19,4 +19,10 @@ public enum ContactPropertyType
     /// </summary>
     [JsonStringValue( "number" )]
     Number,
+
+    /// <summary>
+    /// Boolean.
+    /// </summary>
+    [JsonStringValue( "boolean" )]
+    Boolean,
 }

--- a/src/Resend/ContactPropertyValue.cs
+++ b/src/Resend/ContactPropertyValue.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// Custom property value on a contact.
+/// </summary>
+public class ContactPropertyValue
+{
+    /// <summary>
+    /// Property value.
+    /// </summary>
+    /// <remarks>
+    /// A string, number, or boolean, depending on the type field.
+    /// </remarks>
+    [JsonPropertyName( "value" )]
+    public object? Value { get; set; }
+
+    /// <summary>
+    /// Property data-type.
+    /// </summary>
+    [JsonPropertyName( "type" )]
+    public ContactPropertyType PropertyType { get; set; }
+}

--- a/src/Resend/ContactPropertyValue.cs
+++ b/src/Resend/ContactPropertyValue.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Resend;
@@ -8,13 +9,10 @@ namespace Resend;
 public class ContactPropertyValue
 {
     /// <summary>
-    /// Property value.
+    /// Property value; a string, number, or boolean, depending on <see cref="PropertyType"/>.
     /// </summary>
-    /// <remarks>
-    /// A string, number, or boolean, depending on the type field.
-    /// </remarks>
     [JsonPropertyName( "value" )]
-    public object? Value { get; set; }
+    public JsonElement Value { get; set; }
 
     /// <summary>
     /// Property data-type.

--- a/tests/Resend.Tests/ResendClientTests.cs
+++ b/tests/Resend.Tests/ResendClientTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc.Testing;
 using Resend.ApiServer;
 using System.Net;
+using System.Text.Json;
 
 namespace Resend.Tests;
 
@@ -328,6 +329,11 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
         var resp = await _resend.ContactRetrieveAsync( Guid.NewGuid() );
 
         Assert.NotNull( resp );
+        Assert.NotNull( resp.Content.Properties );
+
+        var tier = resp.Content.Properties[ "tier" ];
+        Assert.Equal( ContactPropertyType.String, tier.PropertyType );
+        Assert.Equal( "premium", ( (JsonElement) tier.Value! ).GetString() );
     }
 
 

--- a/tests/Resend.Tests/ResendClientTests.cs
+++ b/tests/Resend.Tests/ResendClientTests.cs
@@ -333,7 +333,7 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
 
         var tier = resp.Content.Properties[ "tier" ];
         Assert.Equal( ContactPropertyType.String, tier.PropertyType );
-        Assert.Equal( "premium", ( (JsonElement) tier.Value! ).GetString() );
+        Assert.Equal( "premium", tier.Value.GetString() );
     }
 
 

--- a/tools/Resend.ApiServer/Controllers/ContactController.cs
+++ b/tools/Resend.ApiServer/Controllers/ContactController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Resend.Payloads;
+using System.Text.Json;
 
 namespace Resend.ApiServer.Controllers;
 
@@ -49,7 +50,7 @@ public class ContactController : ControllerBase
             IsUnsubscribed = true,
             Properties = new Dictionary<string, ContactPropertyValue>()
             {
-                { "tier", new ContactPropertyValue() { Value = "premium", PropertyType = ContactPropertyType.String } },
+                { "tier", new ContactPropertyValue() { Value = JsonDocument.Parse( "\"premium\"" ).RootElement, PropertyType = ContactPropertyType.String } },
             },
         };
     }

--- a/tools/Resend.ApiServer/Controllers/ContactController.cs
+++ b/tools/Resend.ApiServer/Controllers/ContactController.cs
@@ -47,6 +47,10 @@ public class ContactController : ControllerBase
             LastName = "Test",
             MomentCreated = DateTime.UtcNow.AddDays( -1 ),
             IsUnsubscribed = true,
+            Properties = new Dictionary<string, ContactPropertyValue>()
+            {
+                { "tier", new ContactPropertyValue() { Value = "premium", PropertyType = ContactPropertyType.String } },
+            },
         };
     }
 


### PR DESCRIPTION
`GET /contacts/:id` returns `properties` where each entry is a `{value, type}` object, so the previous `Dictionary<string,string>` threw `JsonException` on the real response. Adds `ContactPropertyValue` (`Value`: string, number, or boolean; `PropertyType` reusing `ContactPropertyType`, with a new `Boolean` member), retypes `Contact.Properties`, and covers it via the mock ApiServer + retrieve test. Create/update request params (`ContactData.Properties`) stay flat maps.

Matches resend-node's `get-contact.interface.ts` and resend-rust's `ContactPropertyResponse`.

docs: https://resend.com/docs/api-reference/contacts/get-contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns contact properties deserialization with the API to prevent JsonException. Previously `Contact.Properties` was `Dictionary<string,string>`; it is now `Dictionary<string, ContactPropertyValue>` where each entry has `{ value: JsonElement, type: ContactPropertyType }`.

- Update code that reads properties: `var p = contact.Properties["key"];` check `p.PropertyType` and use `p.Value.GetString()`/`GetBoolean()`/`GetDouble()`. Code assuming `Dictionary<string,string>` must change.
- Adds `ContactPropertyType.Boolean`. Create/update payloads are unchanged: `ContactData.Properties` remains a flat map.

<sup>Written for commit ad87af28fcb0d5f8ff152f7cd16265ee56806d11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

