### PR TITLE
feat: add ReceivedFor to the received email type

### DIFF
--- a/src/Resend/ReceivedEmail.cs
+++ b/src/Resend/ReceivedEmail.cs
@@ -51,6 +51,14 @@ public class ReceivedEmail
     public EmailAddressList? ReplyTo { get; set; }
 
     /// <summary>
+    /// The recipient addresses the email was forwarded for, taken from the
+    /// <c>for</c> clause of the message's <c>Received</c> headers.
+    /// </summary>
+    [JsonPropertyName( "received_for" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public EmailAddressList? ReceivedFor { get; set; }
+
+    /// <summary>
     /// Message identifier.
     /// </summary>
     [JsonPropertyName( "message_id" )]


### PR DESCRIPTION
The [retrieve received email](https://resend.com/docs/api-reference/emails/retrieve-received-email) endpoint returns a `received_for` array — "the recipient addresses the email was forwarded for, taken from the `for` clause of the message's `Received` headers" — but `ReceivedEmail` had no property for it, so the value was silently dropped on deserialization.

`EmailEventData` in `Resend.Webhooks` already had `ReceivedFor`, so this brings the API model in line with the webhook model. Same `EmailAddressList?` type and `JsonIgnore` pattern as the neighbouring `Cc`/`Bcc`/`ReplyTo` properties.

Two things worth noting:

No test is included because there is no existing test that deserializes `ReceivedEmail` to extend, and a test asserting only that a new property round-trips would restate the attribute rather than cover behaviour. Happy to add one if you would rather have the coverage.

`ReceivedEmail` backs both retrieve and list, so the property appears on list results too, where it will be null. That matches how `TextBody`, `HtmlBody`, and the other retrieve-only fields already behave on this type. The [list endpoint docs](https://resend.com/docs/api-reference/emails/list-received-emails) do not document `received_for`.

Related: the field is still missing from [the OpenAPI spec](https://github.com/resend/resend-openapi/blob/main/resend.yaml), which is what [DEV-1626](https://linear.app/resend/issue/DEV-1626/investigate-missing-received-for-field-in-openapi-spec) is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose forwarded-for recipients on retrieved emails.

Previously, the SDK dropped the retrieve endpoint’s received_for array during deserialization; now `ReceivedEmail.ReceivedFor` captures it, aligning the API model with the webhook `EmailEventData` and docs.

- Uses `EmailAddressList?` with `JsonIgnore(WhenWritingNull)`, matching `Cc`/`Bcc`/`ReplyTo`.
- Appears on list results but will be null, consistent with other retrieve-only fields.
- No migration required; this adds a nullable property.
- Linear DEV-1626: partially addressed by surfacing the field in the SDK; the OpenAPI spec still omits `received_for`.

<sup>Written for commit 1076fa07bcbb96b1753f378b3230d1d9a272103d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




Ref DEV-1626
