### PR TITLE
Bump fallback Version to 0.9.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>0.7.0</Version>
+    <Version>0.9.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- `Directory.Build.props` still had the fallback `<Version>` at `0.7.0`, two releases behind the latest tag (`v0.9.0`). Local `dotnet build`/`dotnet pack` runs (outside CI) would pick up this stale version since it's not overridden by a tag-derived `-p:Version=` like `cicd/release.sh` does for actual releases.
- Bumped it to `0.9.0` to match the latest published release, following the repo's existing convention (see 1173ad5, 0b46e43).

## Test plan
- [x] Confirmed no other file in the repo hardcodes the version (only `Directory.Build.props`)
- [x] `release.sh` derives version from the git tag via `-p:Version=`, so this change doesn't affect the release pipeline itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the fallback package version with the latest release by updating `Directory.Build.props` from 0.7.0 to 0.9.0. This ensures local `dotnet build`/`dotnet pack` runs use 0.9.0 instead of a stale version when no `-p:Version` is provided.

- Affects only local or non-tagged builds; the release pipeline still derives the version from the git tag and is unchanged.
- No code or API changes; no migration required.

<sup>Written for commit 43e4a763179edfb25d2ab0bd1e6aca6e8e30f276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

