### PR TITLE
feat(api-keys): add ApiKeyUpdateAsync for PATCH /api-keys/:id

### DIFF
--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -410,6 +410,28 @@ public interface IResend
     Task<ResendResponse<ApiKeyData>> ApiKeyCreateAsync( string keyName, Permission? permission = null, Guid? domainId = null, CancellationToken cancellationToken = default );
 
     /// <summary>
+    /// Renames an existing API key.
+    /// </summary>
+    /// <param name="apiKeyId">
+    /// API key identifier.
+    /// </param>
+    /// <param name="name">
+    /// New display name for the API key.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancellation token.
+    /// </param>
+    /// <returns>
+    /// API key identifier.
+    /// </returns>
+    /// <remarks>
+    /// Permission and domain restriction cannot be changed through this method; delete
+    /// and re-create the key if those need to change.
+    /// </remarks>
+    /// <see href="https://resend.com/docs/api-reference/api-keys/update-api-key" />
+    Task<ResendResponse<Guid>> ApiKeyUpdateAsync( Guid apiKeyId, string name, CancellationToken cancellationToken = default );
+
+    /// <summary>
     /// Remove an existing API key.
     /// </summary>
     /// <param name="apiKeyId">

--- a/src/Resend/Payloads/ApiKeyUpdateRequest.cs
+++ b/src/Resend/Payloads/ApiKeyUpdateRequest.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Resend.Payloads;
+
+/// <summary>
+/// Request object to update an API key.
+/// </summary>
+public class ApiKeyUpdateRequest
+{
+    /// <summary>
+    /// Name of API key.
+    /// </summary>
+    [JsonPropertyName( "name" )]
+    public string Name { get; set; } = default!;
+}

--- a/src/Resend/ResendClient.cs
+++ b/src/Resend/ResendClient.cs
@@ -309,6 +309,20 @@ public partial class ResendClient : IResend
 
 
     /// <inheritdoc />
+    public Task<ResendResponse<Guid>> ApiKeyUpdateAsync( Guid apiKeyId, string name, CancellationToken cancellationToken = default )
+    {
+        var path = $"/api-keys/{apiKeyId}";
+        var req = new HttpRequestMessage( HttpMethod.Patch, path );
+        req.Content = JsonContent.Create( new ApiKeyUpdateRequest()
+        {
+            Name = name,
+        } );
+
+        return Execute<ObjectId, Guid>( req, ( x ) => x.Id, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
     public Task<ResendResponse<List<ApiKey>>> ApiKeyListAsync( CancellationToken cancellationToken = default )
     {
         var path = $"/api-keys";

--- a/tests/Resend.Tests/ApiKeyRequestTests.cs
+++ b/tests/Resend.Tests/ApiKeyRequestTests.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using System.Text;
+
+namespace Resend.Tests;
+
+/// <summary>
+/// Tests over the requests issued by the api key methods, against a handler which records
+/// instead of answering like the API.
+/// </summary>
+public class ApiKeyRequestTests
+{
+    private readonly RecordingHandler _handler;
+    private readonly IResend _resend;
+
+
+    /// <summary />
+    public ApiKeyRequestTests()
+    {
+        _handler = new RecordingHandler();
+
+        var opt = new ResendClientOptions()
+        {
+            ApiToken = "re_test_123",
+        };
+
+        _resend = ResendClient.Create( opt, new HttpClient( _handler ) );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task ApiKeyUpdate_SendsPatchWithName()
+    {
+        var apiKeyId = Guid.NewGuid();
+
+        await _resend.ApiKeyUpdateAsync( apiKeyId, "renamed key" );
+
+        var req = Assert.Single( _handler.Requests );
+        Assert.Equal( HttpMethod.Patch, req.Method );
+        Assert.Equal( $"/api-keys/{apiKeyId}", req.RequestUri!.PathAndQuery );
+
+        var body = await req.Content!.ReadAsStringAsync();
+        Assert.Contains( "\"name\":\"renamed key\"", body );
+    }
+
+
+    /// <summary />
+    private class RecordingHandler : HttpMessageHandler
+    {
+        /// <summary />
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+
+        /// <inheritdoc />
+        protected override Task<HttpResponseMessage> SendAsync( HttpRequestMessage request, CancellationToken cancellationToken )
+        {
+            Requests.Add( request );
+
+            var resp = new HttpResponseMessage( HttpStatusCode.OK );
+            resp.Content = new StringContent( $$"""{"object":"api_key","id":"{{Guid.NewGuid()}}"}""", Encoding.UTF8, "application/json" );
+
+            return Task.FromResult( resp );
+        }
+    }
+}

--- a/tests/Resend.Tests/ResendClientTests.cs
+++ b/tests/Resend.Tests/ResendClientTests.cs
@@ -216,6 +216,18 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
 
     /// <summary />
     [Fact]
+    public async Task ApiKeyUpdate()
+    {
+        var resp = await _resend.ApiKeyUpdateAsync( Guid.NewGuid(), "renamed-key" );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotEqual( Guid.Empty, resp.Content );
+    }
+
+
+    /// <summary />
+    [Fact]
     public async Task ApiKeyDelete()
     {
         var resp = await _resend.ApiKeyDeleteAsync( Guid.NewGuid() );

--- a/tools/Resend.ApiServer/Controllers/ApiKeyController.cs
+++ b/tools/Resend.ApiServer/Controllers/ApiKeyController.cs
@@ -33,6 +33,21 @@ public class ApiKeyController : ControllerBase
 
 
     /// <summary />
+    [HttpPatch]
+    [Route( "api-keys/{id}" )]
+    public ObjectId ApiKeyUpdate( [FromRoute] Guid id, [FromBody] ApiKeyUpdateRequest request )
+    {
+        _logger.LogDebug( "ApiKeyUpdate" );
+
+        return new ObjectId()
+        {
+            Object = "api_key",
+            Id = id,
+        };
+    }
+
+
+    /// <summary />
     [HttpGet]
     [Route( "api-keys" )]
     public ListOf<ApiKey> ApiKeyList()

--- a/tools/Resend.Cli/ApiKey/ApiKeyUpdateCommand.cs
+++ b/tools/Resend.Cli/ApiKey/ApiKeyUpdateCommand.cs
@@ -1,0 +1,38 @@
+using McMaster.Extensions.CommandLineUtils;
+using System.ComponentModel.DataAnnotations;
+
+namespace Resend.Cli.ApiKey;
+
+/// <summary />
+[Command( "update", Description = "Rename an API key" )]
+public class ApiKeyUpdateCommand
+{
+    private readonly IResend _resend;
+
+
+    /// <summary />
+    [Argument( 0, Description = "API key identifier" )]
+    [Required]
+    public Guid? KeyId { get; set; }
+
+    /// <summary />
+    [Argument( 1, Description = "New API key name" )]
+    [Required]
+    public string KeyName { get; set; } = default!;
+
+
+    /// <summary />
+    public ApiKeyUpdateCommand( IResend resend )
+    {
+        _resend = resend;
+    }
+
+
+    /// <summary />
+    public async Task<int> OnExecuteAsync()
+    {
+        await _resend.ApiKeyUpdateAsync( this.KeyId!.Value, this.KeyName );
+
+        return 0;
+    }
+}

--- a/tools/Resend.Cli/ApiKeyCommand.cs
+++ b/tools/Resend.Cli/ApiKeyCommand.cs
@@ -6,6 +6,7 @@ namespace Resend.Cli;
 [Command( "apikey", Description = "API key management" )]
 [Subcommand( typeof( ApiKey.ApiKeyCreateCommand ))]
 [Subcommand( typeof( ApiKey.ApiKeyListCommand ))]
+[Subcommand( typeof( ApiKey.ApiKeyUpdateCommand ) )]
 [Subcommand( typeof( ApiKey.ApiKeyDeleteCommand ) )]
 public class ApiKeyCommand
 {


### PR DESCRIPTION
## Summary
- Adds `ApiKeyUpdateAsync(Guid apiKeyId, string name)` to the library, plus an `apikey update` CLI subcommand, for the new `PATCH /api-keys/:id` endpoint — see https://resend.com/docs/api-reference/api-keys/update-api-key.
- Only `name` is patchable. `permission`/`domain_id` are deliberately not exposed — the endpoint doesn't accept them (prevents a leaked management key from silently widening another key's scope).

Draft — SDK rollout in progress, tracked in Linear as DEV-1219.

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] `dotnet test -c Release --no-build` — all passing (189/189)
- [x] CLI sanity check: `resend-cli apikey update --help`