### PR TITLE
Bump fallback Version to 0.11.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- `Directory.Build.props` still had the fallback `<Version>` at `0.10.0`, behind the release about to be cut (`v0.11.0`, covering #142 EmailShareAsync and #143 api-keys update). Local `dotnet build`/`dotnet pack` runs (outside CI) would pick up this stale version since it's not overridden by a tag-derived `-p:Version=` like `cicd/release.sh` does for actual releases.
- Bumped it to `0.11.0` to match the upcoming release, following the repo's existing convention (see #141, #131).

## Test plan
- [x] Confirmed no other file in the repo hardcodes the version (only `Directory.Build.props`)
- [x] `dotnet build -c Release` succeeds with only the two pre-existing unrelated warnings
- [x] `release.sh` derives version from the git tag via `-p:Version=`, so this change doesn't affect the release pipeline itself

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the fallback package version with the upcoming release by updating Directory.Build.props from 0.10.0 to 0.11.0. Previously, local dotnet builds/packs defaulted to 0.10.0; now they default to 0.11.0. The release pipeline remains unchanged since it injects the version via -p:Version from the tag.

- Single-line change; no other files hardcode a version.
- No rollout impact; local scripts that relied on the 0.10.0 fallback should update expectations.

<sup>Written for commit c3e5f00e98ae9b5f9933ed76ece2791c432ab9de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

