### PR TITLE
feat: add BroadcastListRecipientsAsync method

### DIFF
--- a/src/Resend/BroadcastListRecipientsQuery.cs
+++ b/src/Resend/BroadcastListRecipientsQuery.cs
@@ -1,0 +1,20 @@
+namespace Resend;
+
+/// <summary>
+/// Query parameters for <see cref="IResend.BroadcastListRecipientsAsync"/>.
+/// </summary>
+public class BroadcastListRecipientsQuery : PaginatedQuery
+{
+    /// <summary>
+    /// Filters recipients whose email contains this value.
+    /// </summary>
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Filters bounced recipients by bounce classification.
+    /// </summary>
+    /// <remarks>
+    /// Only meaningful when the requested event type is <see cref="BroadcastRecipientEventType.Bounced"/>.
+    /// </remarks>
+    public BroadcastRecipientBounceType? BounceType { get; set; }
+}

--- a/src/Resend/BroadcastRecipient.cs
+++ b/src/Resend/BroadcastRecipient.cs
@@ -1,0 +1,68 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// A broadcast recipient, as returned for a given <see cref="BroadcastRecipientEventType"/>.
+/// </summary>
+/// <see href="https://resend.com/docs/api-reference/broadcasts/list-broadcast-recipients" />
+public class BroadcastRecipient
+{
+    /// <summary>
+    /// Opaque cursor identifying this row, used only for pagination.
+    /// </summary>
+    /// <remarks>
+    /// Does not identify any entity in Resend -- use <see cref="ContactId"/> to reference
+    /// the contact.
+    /// </remarks>
+    [JsonPropertyName( "id" )]
+    public string Id { get; set; } = default!;
+
+    /// <summary>
+    /// Identifier of the contact matching this recipient.
+    /// </summary>
+    /// <remarks>
+    /// Null when the recipient's email no longer maps to a contact.
+    /// </remarks>
+    [JsonPropertyName( "contact_id" )]
+    public Guid? ContactId { get; set; }
+
+    /// <summary>
+    /// The recipient's email address.
+    /// </summary>
+    [JsonPropertyName( "email" )]
+    public string Email { get; set; } = default!;
+
+    /// <summary>
+    /// Number of times this recipient triggered the event.
+    /// </summary>
+    /// <remarks>
+    /// Only present when the requested <see cref="BroadcastRecipientEventType"/> is
+    /// <see cref="BroadcastRecipientEventType.Opened"/> or <see cref="BroadcastRecipientEventType.Clicked"/>.
+    /// </remarks>
+    [JsonPropertyName( "count" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public int? Count { get; set; }
+
+    /// <summary>
+    /// The bounce classification.
+    /// </summary>
+    /// <remarks>
+    /// Only present when the requested <see cref="BroadcastRecipientEventType"/> is
+    /// <see cref="BroadcastRecipientEventType.Bounced"/>.
+    /// </remarks>
+    [JsonPropertyName( "bounce_type" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public BroadcastRecipientBounceType? BounceType { get; set; }
+
+    /// <summary>
+    /// The links this recipient clicked.
+    /// </summary>
+    /// <remarks>
+    /// Only present when the requested <see cref="BroadcastRecipientEventType"/> is
+    /// <see cref="BroadcastRecipientEventType.Clicked"/>.
+    /// </remarks>
+    [JsonPropertyName( "clicked_links" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public List<BroadcastRecipientClickedLink>? ClickedLinks { get; set; }
+}

--- a/src/Resend/BroadcastRecipientBounceType.cs
+++ b/src/Resend/BroadcastRecipientBounceType.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// Broadcast recipient bounce classifications.
+/// </summary>
+[JsonConverter( typeof( JsonStringEnumValueConverter<BroadcastRecipientBounceType> ) )]
+public enum BroadcastRecipientBounceType
+{
+    /// <summary>
+    /// The bounce is permanent; the address is not expected to become deliverable.
+    /// </summary>
+    [JsonStringValue( "permanent" )]
+    Permanent,
+
+    /// <summary>
+    /// The bounce is transient; the address may become deliverable again.
+    /// </summary>
+    [JsonStringValue( "transient" )]
+    Transient,
+
+    /// <summary>
+    /// The bounce could not be classified.
+    /// </summary>
+    [JsonStringValue( "undetermined" )]
+    Undetermined,
+}

--- a/src/Resend/BroadcastRecipientClickedLink.cs
+++ b/src/Resend/BroadcastRecipientClickedLink.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// A link clicked by a broadcast recipient.
+/// </summary>
+public class BroadcastRecipientClickedLink
+{
+    /// <summary>
+    /// The clicked URL.
+    /// </summary>
+    [JsonPropertyName( "url" )]
+    public string Url { get; set; } = default!;
+
+    /// <summary>
+    /// Number of times this recipient clicked this URL.
+    /// </summary>
+    [JsonPropertyName( "clicks" )]
+    public int Clicks { get; set; }
+}

--- a/src/Resend/BroadcastRecipientEventType.cs
+++ b/src/Resend/BroadcastRecipientEventType.cs
@@ -1,0 +1,58 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// Broadcast recipient event types.
+/// </summary>
+[JsonConverter( typeof( JsonStringEnumValueConverter<BroadcastRecipientEventType> ) )]
+public enum BroadcastRecipientEventType
+{
+    /// <summary>
+    /// Recipient the broadcast was sent to.
+    /// </summary>
+    [JsonStringValue( "sent" )]
+    Sent,
+
+    /// <summary>
+    /// Recipient whose email was delivered.
+    /// </summary>
+    [JsonStringValue( "delivered" )]
+    Delivered,
+
+    /// <summary>
+    /// Recipient who opened the email.
+    /// </summary>
+    [JsonStringValue( "opened" )]
+    Opened,
+
+    /// <summary>
+    /// Recipient who clicked a link in the email.
+    /// </summary>
+    [JsonStringValue( "clicked" )]
+    Clicked,
+
+    /// <summary>
+    /// Recipient whose email bounced.
+    /// </summary>
+    [JsonStringValue( "bounced" )]
+    Bounced,
+
+    /// <summary>
+    /// Recipient who marked the email as spam.
+    /// </summary>
+    [JsonStringValue( "complained" )]
+    Complained,
+
+    /// <summary>
+    /// Recipient who unsubscribed.
+    /// </summary>
+    [JsonStringValue( "unsubscribed" )]
+    Unsubscribed,
+
+    /// <summary>
+    /// Recipient who was suppressed and did not receive the email.
+    /// </summary>
+    [JsonStringValue( "suppressed" )]
+    Suppressed,
+}

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -846,6 +846,17 @@ public interface IResend
     Task<ResendResponse<List<Broadcast>>> BroadcastListAsync( CancellationToken cancellationToken = default );
 
     /// <summary>
+    /// Lists a broadcast's recipients for a given event type.
+    /// </summary>
+    /// <param name="broadcastId">Broadcast identifier.</param>
+    /// <param name="type">Recipient event type to filter by.</param>
+    /// <param name="query">Filters and pagination.</param>
+    /// <param name="cancellationToken">Cancelation token.</param>
+    /// <returns>Page of recipients.</returns>
+    /// <see href="https://resend.com/docs/api-reference/broadcasts/list-broadcast-recipients"/>
+    Task<ResendResponse<PaginatedResult<BroadcastRecipient>>> BroadcastListRecipientsAsync( Guid broadcastId, BroadcastRecipientEventType type, BroadcastListRecipientsQuery? query = null, CancellationToken cancellationToken = default );
+
+    /// <summary>
     /// Removes a broadcast.
     /// </summary>
     /// <param name="broadcastId">Broadcast identifier.</param>

--- a/src/Resend/ResendClient.cs
+++ b/src/Resend/ResendClient.cs
@@ -504,7 +504,12 @@ public partial class ResendClient : IResend
                 qs.Add( "email", query.Email );
 
             if ( query.BounceType.HasValue == true )
+            {
+                if ( type != BroadcastRecipientEventType.Bounced )
+                    throw new ArgumentException( "BounceType can only be set when type is Bounced.", nameof( query ) );
+
                 qs.Add( "bounce_type", JsonStringEnumValue<BroadcastRecipientBounceType>.Of( query.BounceType.Value ) );
+            }
         }
 
         var url = QueryHelpers.AddQueryString( baseUrl, qs );

--- a/src/Resend/ResendClient.cs
+++ b/src/Resend/ResendClient.cs
@@ -480,6 +480,42 @@ public partial class ResendClient : IResend
 
 
     /// <inheritdoc/>
+    public Task<ResendResponse<PaginatedResult<BroadcastRecipient>>> BroadcastListRecipientsAsync( Guid broadcastId, BroadcastRecipientEventType type, BroadcastListRecipientsQuery? query = null, CancellationToken cancellationToken = default )
+    {
+        var baseUrl = $"/broadcasts/{broadcastId}/recipients";
+
+        var qs = new Dictionary<string, string?>()
+        {
+            { "type", JsonStringEnumValue<BroadcastRecipientEventType>.Of( type ) },
+        };
+
+        if ( query != null )
+        {
+            if ( query.Limit.HasValue == true )
+                qs.Add( "limit", query.Limit.Value.ToString() );
+
+            if ( query.Before != null )
+                qs.Add( "before", query.Before );
+
+            if ( query.After != null )
+                qs.Add( "after", query.After );
+
+            if ( query.Email != null )
+                qs.Add( "email", query.Email );
+
+            if ( query.BounceType.HasValue == true )
+                qs.Add( "bounce_type", JsonStringEnumValue<BroadcastRecipientBounceType>.Of( query.BounceType.Value ) );
+        }
+
+        var url = QueryHelpers.AddQueryString( baseUrl, qs );
+
+        var req = new HttpRequestMessage( HttpMethod.Get, url );
+
+        return Execute<PaginatedResult<BroadcastRecipient>, PaginatedResult<BroadcastRecipient>>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    /// <inheritdoc/>
     public Task<ResendResponse> BroadcastDeleteAsync( Guid broadcastId, CancellationToken cancellationToken = default )
     {
         var path = $"/broadcasts/{broadcastId}";

--- a/tests/Resend.Tests/ResendClientTests.cs
+++ b/tests/Resend.Tests/ResendClientTests.cs
@@ -586,6 +586,17 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
 
     /// <summary/>
     [Fact]
+    public async Task BroadcastListRecipientsBounceTypeRequiresBouncedType()
+    {
+        await Assert.ThrowsAsync<ArgumentException>( () => _resend.BroadcastListRecipientsAsync(
+            Guid.NewGuid(),
+            BroadcastRecipientEventType.Delivered,
+            new BroadcastListRecipientsQuery() { BounceType = BroadcastRecipientBounceType.Permanent } ) );
+    }
+
+
+    /// <summary/>
+    [Fact]
     public async Task BroadcastListRecipientsNotFound()
     {
         var ex = await Assert.ThrowsAsync<ResendException>( () => _resend.BroadcastListRecipientsAsync( Guid.Empty, BroadcastRecipientEventType.Delivered ) );

--- a/tests/Resend.Tests/ResendClientTests.cs
+++ b/tests/Resend.Tests/ResendClientTests.cs
@@ -493,6 +493,110 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
 
     /// <summary/>
     [Fact]
+    public async Task BroadcastListRecipients()
+    {
+        var resp = await _resend.BroadcastListRecipientsAsync( Guid.NewGuid(), BroadcastRecipientEventType.Delivered );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.True( resp.Content.HasMore );
+        Assert.Single( resp.Content.Data );
+
+        var recipient = resp.Content.Data[ 0 ];
+        Assert.NotEqual( "", recipient.Id );
+        Assert.NotNull( recipient.ContactId );
+        Assert.NotEqual( "", recipient.Email );
+        Assert.Null( recipient.Count );
+        Assert.Null( recipient.BounceType );
+        Assert.Null( recipient.ClickedLinks );
+    }
+
+
+    /// <summary/>
+    [Fact]
+    public async Task BroadcastListRecipientsOpened()
+    {
+        var resp = await _resend.BroadcastListRecipientsAsync( Guid.NewGuid(), BroadcastRecipientEventType.Opened );
+
+        Assert.NotNull( resp );
+        Assert.NotNull( resp.Content );
+
+        var recipient = resp.Content.Data[ 0 ];
+        Assert.Equal( 3, recipient.Count );
+        Assert.Null( recipient.BounceType );
+        Assert.Null( recipient.ClickedLinks );
+    }
+
+
+    /// <summary/>
+    [Fact]
+    public async Task BroadcastListRecipientsClicked()
+    {
+        var resp = await _resend.BroadcastListRecipientsAsync( Guid.NewGuid(), BroadcastRecipientEventType.Clicked );
+
+        Assert.NotNull( resp );
+        Assert.NotNull( resp.Content );
+
+        var recipient = resp.Content.Data[ 0 ];
+        Assert.Equal( 3, recipient.Count );
+        Assert.NotNull( recipient.ClickedLinks );
+        Assert.Single( recipient.ClickedLinks );
+        Assert.Equal( "https://resend.com/pricing", recipient.ClickedLinks[ 0 ].Url );
+        Assert.Equal( 2, recipient.ClickedLinks[ 0 ].Clicks );
+    }
+
+
+    /// <summary/>
+    [Fact]
+    public async Task BroadcastListRecipientsBounced()
+    {
+        var resp = await _resend.BroadcastListRecipientsAsync(
+            Guid.NewGuid(),
+            BroadcastRecipientEventType.Bounced,
+            new BroadcastListRecipientsQuery() { BounceType = BroadcastRecipientBounceType.Transient } );
+
+        Assert.NotNull( resp );
+        Assert.NotNull( resp.Content );
+
+        var recipient = resp.Content.Data[ 0 ];
+        Assert.Equal( BroadcastRecipientBounceType.Transient, recipient.BounceType );
+    }
+
+
+    /// <summary/>
+    [Fact]
+    public async Task BroadcastListRecipientsWithQuery()
+    {
+        var resp = await _resend.BroadcastListRecipientsAsync(
+            Guid.NewGuid(),
+            BroadcastRecipientEventType.Delivered,
+            new BroadcastListRecipientsQuery()
+            {
+                Email = "steve.wozniak@gmail.com",
+                Limit = 10,
+                After = Guid.NewGuid().ToString(),
+            } );
+
+        Assert.NotNull( resp );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( "steve.wozniak@gmail.com", resp.Content.Data[ 0 ].Email );
+    }
+
+
+    /// <summary/>
+    [Fact]
+    public async Task BroadcastListRecipientsNotFound()
+    {
+        var ex = await Assert.ThrowsAsync<ResendException>( () => _resend.BroadcastListRecipientsAsync( Guid.Empty, BroadcastRecipientEventType.Delivered ) );
+
+        Assert.Equal( HttpStatusCode.NotFound, ex.StatusCode );
+        Assert.Equal( ErrorType.NotFound, ex.ErrorType );
+    }
+
+
+    /// <summary/>
+    [Fact]
     public async Task BroadcastDelete()
     {
         var resp = await _resend.BroadcastDeleteAsync( Guid.NewGuid() );

--- a/tools/Resend.ApiServer/Controllers/BroadcastController.cs
+++ b/tools/Resend.ApiServer/Controllers/BroadcastController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Resend.Payloads;
+using System.Net;
 
 namespace Resend.ApiServer.Controllers;
 
@@ -87,6 +88,72 @@ public class BroadcastController : ControllerBase
         _logger.LogDebug( "BroadcastCancel" );
 
         return Ok();
+    }
+
+
+    /// <summary>
+    /// The fake server has no persisted state, so the well-known empty id doubles as the
+    /// "broadcast not found" fixture for tests, mirroring <see cref="EmailController.EmailShare"/>.
+    /// </summary>
+    [HttpGet]
+    [Route( "broadcasts/{broadcastId}/recipients" )]
+    public ActionResult<PaginatedResult<BroadcastRecipient>> BroadcastListRecipients(
+        [FromRoute] Guid broadcastId,
+        [FromQuery( Name = "type" )] string type,
+        [FromQuery( Name = "email" )] string? email,
+        [FromQuery( Name = "bounce_type" )] string? bounceType,
+        [FromQuery( Name = "limit" )] int? limit,
+        [FromQuery( Name = "after" )] string? after,
+        [FromQuery( Name = "before" )] string? before )
+    {
+        _logger.LogDebug( "BroadcastListRecipients" );
+
+        if ( broadcastId == Guid.Empty )
+        {
+            return NotFound( new ErrorResponse()
+            {
+                StatusCode = (int) HttpStatusCode.NotFound,
+                ErrorType = ErrorType.NotFound,
+                Message = "Broadcast not found",
+            } );
+        }
+
+        var recipient = new BroadcastRecipient()
+        {
+            Id = "b2Zmc2V0OjA",
+            ContactId = Guid.NewGuid(),
+            Email = email ?? "steve.wozniak@gmail.com",
+        };
+
+        switch ( type )
+        {
+            case "opened":
+                recipient.Count = 3;
+                break;
+
+            case "clicked":
+                recipient.Count = 3;
+                recipient.ClickedLinks = new List<BroadcastRecipientClickedLink>()
+                {
+                    new BroadcastRecipientClickedLink() { Url = "https://resend.com/pricing", Clicks = 2 },
+                };
+                break;
+
+            case "bounced":
+                recipient.BounceType = bounceType switch
+                {
+                    "transient" => BroadcastRecipientBounceType.Transient,
+                    "undetermined" => BroadcastRecipientBounceType.Undetermined,
+                    _ => BroadcastRecipientBounceType.Permanent,
+                };
+                break;
+        }
+
+        return new PaginatedResult<BroadcastRecipient>()
+        {
+            HasMore = true,
+            Data = new List<BroadcastRecipient>() { recipient },
+        };
     }
 
 

--- a/tools/Resend.Cli/Broadcast/BroadcastListRecipientsCommand.cs
+++ b/tools/Resend.Cli/Broadcast/BroadcastListRecipientsCommand.cs
@@ -77,7 +77,7 @@ public class BroadcastListRecipientsCommand
         {
             var jso = new JsonSerializerOptions() { WriteIndented = true, };
 
-            var json = JsonSerializer.Serialize( results, jso );
+            var json = JsonSerializer.Serialize( results.Data, jso );
             Console.WriteLine( json );
         }
         else
@@ -94,12 +94,12 @@ public class BroadcastListRecipientsCommand
             foreach ( var d in results.Data )
             {
                 table.AddRow(
-                    new Markup( d.Id ),
-                    new Markup( d.ContactId?.ToString() ?? "" ),
-                    new Markup( d.Email ),
+                    new Markup( Markup.Escape( d.Id ) ),
+                    new Markup( Markup.Escape( d.ContactId?.ToString() ?? "" ) ),
+                    new Markup( Markup.Escape( d.Email ) ),
                     new Markup( d.Count?.ToString() ?? "" ),
                     new Markup( d.BounceType?.ToString() ?? "" ),
-                    new Markup( d.ClickedLinks == null ? "" : string.Join( ", ", d.ClickedLinks.Select( x => $"{x.Url} ({x.Clicks})" ) ) )
+                    new Markup( Markup.Escape( d.ClickedLinks == null ? "" : string.Join( ", ", d.ClickedLinks.Select( x => $"{x.Url} ({x.Clicks})" ) ) ) )
                 );
             }
 

--- a/tools/Resend.Cli/Broadcast/BroadcastListRecipientsCommand.cs
+++ b/tools/Resend.Cli/Broadcast/BroadcastListRecipientsCommand.cs
@@ -1,0 +1,111 @@
+using McMaster.Extensions.CommandLineUtils;
+using Spectre.Console;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+
+namespace Resend.Cli.Broadcast;
+
+/// <summary />
+[Command( "recipients", Description = "Lists a broadcast's recipients for a given event type" )]
+public class BroadcastListRecipientsCommand
+{
+    private readonly IResend _resend;
+
+
+    /// <summary />
+    [Argument( 0, Description = "Broadcast identifier" )]
+    [Required]
+    public Guid? BroadcastId { get; set; }
+
+    /// <summary />
+    [Argument( 1, Description = "Recipient event type" )]
+    [Required]
+    public BroadcastRecipientEventType? Type { get; set; }
+
+    /// <summary />
+    [Option( "-e|--email", CommandOptionType.SingleValue, Description = "Filter recipients whose email contains this value" )]
+    public string? Email { get; set; }
+
+    /// <summary />
+    [Option( "--bounce-type", CommandOptionType.SingleValue, Description = "Filter bounced recipients by bounce type (only valid when type is bounced)" )]
+    public BroadcastRecipientBounceType? BounceType { get; set; }
+
+    /// <summary />
+    [Option( "-l|--limit", CommandOptionType.SingleValue, Description = "Number of recipients to return" )]
+    public int? Limit { get; set; }
+
+    /// <summary />
+    [Option( "-b|--before", CommandOptionType.SingleValue, Description = "Recipients before cursor" )]
+    public string? BeforeId { get; set; }
+
+    /// <summary />
+    [Option( "-a|--after", CommandOptionType.SingleValue, Description = "Recipients after cursor" )]
+    public string? AfterId { get; set; }
+
+    /// <summary />
+    [Option( "-j|--json", CommandOptionType.NoValue, Description = "Emit output as JSON array" )]
+    public bool InJson { get; set; }
+
+
+    /// <summary />
+    public BroadcastListRecipientsCommand( IResend resend )
+    {
+        _resend = resend;
+    }
+
+
+    /// <summary />
+    public async Task<int> OnExecuteAsync()
+    {
+        var q = new BroadcastListRecipientsQuery()
+        {
+            Email = this.Email,
+            BounceType = this.BounceType,
+            Limit = this.Limit,
+            Before = this.BeforeId,
+            After = this.AfterId,
+        };
+
+        var res = await _resend.BroadcastListRecipientsAsync( this.BroadcastId!.Value, this.Type!.Value, q );
+        var results = res.Content;
+
+
+        /*
+         *
+         */
+        if ( this.InJson == true )
+        {
+            var jso = new JsonSerializerOptions() { WriteIndented = true, };
+
+            var json = JsonSerializer.Serialize( results, jso );
+            Console.WriteLine( json );
+        }
+        else
+        {
+            var table = new Table();
+            table.Border = TableBorder.SimpleHeavy;
+            table.AddColumn( "Id" );
+            table.AddColumn( "Contact Id" );
+            table.AddColumn( "Email" );
+            table.AddColumn( "Count" );
+            table.AddColumn( "Bounce Type" );
+            table.AddColumn( "Clicked Links" );
+
+            foreach ( var d in results.Data )
+            {
+                table.AddRow(
+                    new Markup( d.Id ),
+                    new Markup( d.ContactId?.ToString() ?? "" ),
+                    new Markup( d.Email ),
+                    new Markup( d.Count?.ToString() ?? "" ),
+                    new Markup( d.BounceType?.ToString() ?? "" ),
+                    new Markup( d.ClickedLinks == null ? "" : string.Join( ", ", d.ClickedLinks.Select( x => $"{x.Url} ({x.Clicks})" ) ) )
+                );
+            }
+
+            AnsiConsole.Write( table );
+        }
+
+        return 0;
+    }
+}

--- a/tools/Resend.Cli/BroadcastCommand.cs
+++ b/tools/Resend.Cli/BroadcastCommand.cs
@@ -8,6 +8,7 @@ namespace Resend.Cli;
 [Subcommand( typeof( Broadcast.BroadcastCancelCommand ) )]
 [Subcommand( typeof( Broadcast.BroadcastDeleteCommand ) )]
 [Subcommand( typeof( Broadcast.BroadcastListCommand ) )]
+[Subcommand( typeof( Broadcast.BroadcastListRecipientsCommand ) )]
 [Subcommand( typeof( Broadcast.BroadcastRetrieveCommand ))]
 [Subcommand( typeof( Broadcast.BroadcastScheduleCommand ) )]
 [Subcommand( typeof( Broadcast.BroadcastSendCommand ) )]


### PR DESCRIPTION
Adds `BroadcastListRecipientsAsync` for `GET /broadcasts/{id}/recipients`, plus a matching CLI command.

Spec: https://github.com/resend/resend-openapi/pull/97
Node reference: https://github.com/resend/resend-node/pull/1078

Tests: 192/192. Build clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an API and CLI to list a broadcast’s recipients by event type. Previously clients couldn’t fetch recipients; now they can paginate and filter by email or bounce type with event-specific details, without breaking existing behavior.

- Adds BroadcastListRecipientsAsync(Guid broadcastId, BroadcastRecipientEventType type, BroadcastListRecipientsQuery? query) returning PaginatedResult<BroadcastRecipient>; introduces enums/models for event types, bounce types, clicked links, and per-recipient counts for opened/clicked.
- Validates bounce-type usage: the client rejects BounceType unless type is Bounced; the CLI enforces the same.
- Adds CLI subcommand: resend broadcast recipients <broadcastId> <type> with --email, --bounce-type, --limit, --before, --after, --json; JSON output is a proper array and table cells are escaped.
- Extends the fake API server for GET /broadcasts/{id}/recipients (NotFound for Guid.Empty) and covers the endpoint with tests.

<sup>Written for commit 234cc5d5e6b9b4dbbc719a37de6df5c27ea8f925. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

