### PR TITLE
feat: add EmailMetricsAsync for account-level email metrics

### DIFF
--- a/src/Resend/EmailMetrics.cs
+++ b/src/Resend/EmailMetrics.cs
@@ -1,0 +1,60 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// Email metrics for a given reporting period.
+/// </summary>
+/// <see href="https://resend.com/docs/api-reference/emails/retrieve-email-metrics"/>
+public class EmailMetrics
+{
+    /// <summary />
+    [JsonPropertyName( "object" )]
+    public string Object { get; set; } = default!;
+
+    /// <summary>
+    /// Start of the reporting period.
+    /// </summary>
+    [JsonPropertyName( "start_date" )]
+    [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
+    public DateTime StartDate { get; set; }
+
+    /// <summary>
+    /// End of the reporting period.
+    /// </summary>
+    [JsonPropertyName( "end_date" )]
+    [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
+    public DateTime EndDate { get; set; }
+
+    /// <summary>
+    /// Metrics included in this response.
+    /// </summary>
+    [JsonPropertyName( "metrics" )]
+    public List<MetricType> Metrics { get; set; } = default!;
+
+    /// <summary>
+    /// Dimensions this response is broken down by.
+    /// </summary>
+    [JsonPropertyName( "dimensions" )]
+    public List<MetricDimension> Dimensions { get; set; } = default!;
+
+    /// <summary>
+    /// Bucket size used for the <see cref="MetricDimension.Period"/> dimension.
+    /// </summary>
+    [JsonPropertyName( "granularity" )]
+    public MetricsGranularity Granularity { get; set; }
+
+    /// <summary>
+    /// Totals for the whole reporting period, one entry per requested metric.
+    /// </summary>
+    [JsonPropertyName( "totals" )]
+    public Dictionary<string, double> Totals { get; set; } = default!;
+
+    /// <summary>
+    /// One row per combination of the requested dimensions. Absent when no dimensions
+    /// were requested -- in that case only <see cref="Totals"/> is populated.
+    /// </summary>
+    [JsonPropertyName( "data" )]
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public List<EmailMetricsDataPoint>? Data { get; set; }
+}

--- a/src/Resend/EmailMetrics.cs
+++ b/src/Resend/EmailMetrics.cs
@@ -5,7 +5,7 @@ namespace Resend;
 /// <summary>
 /// Email metrics for a given reporting period.
 /// </summary>
-/// <see href="https://resend.com/docs/api-reference/emails/retrieve-email-metrics"/>
+/// <see href="https://resend.com/docs/api-reference/emails/get-metrics"/>
 public class EmailMetrics
 {
     /// <summary />

--- a/src/Resend/EmailMetricsDataPoint.cs
+++ b/src/Resend/EmailMetricsDataPoint.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// One row of <see cref="EmailMetrics.Data"/>. Which dimension fields are populated depends on
+/// the dimensions requested via <see cref="EmailMetricsQuery.Dimensions"/>.
+/// </summary>
+public class EmailMetricsDataPoint
+{
+    /// <summary>
+    /// Time bucket this row covers, present when <see cref="MetricDimension.Period"/> was requested.
+    /// </summary>
+    [JsonPropertyName( "period" )]
+    public string? Period { get; set; }
+
+    /// <summary>
+    /// Sending domain identifier, present when <see cref="MetricDimension.Domain"/> was requested.
+    /// </summary>
+    [JsonPropertyName( "domain_id" )]
+    public Guid? DomainId { get; set; }
+
+    /// <summary>
+    /// Sending domain name, present when <see cref="MetricDimension.Domain"/> was requested.
+    /// </summary>
+    [JsonPropertyName( "domain_name" )]
+    public string? DomainName { get; set; }
+
+    /// <summary>
+    /// Email identifier, present when <see cref="MetricDimension.Email"/> was requested.
+    /// </summary>
+    [JsonPropertyName( "email_id" )]
+    public Guid? EmailId { get; set; }
+
+    /// <summary>
+    /// Broadcast identifier, present when <see cref="MetricDimension.Broadcast"/> was requested.
+    /// </summary>
+    [JsonPropertyName( "broadcast_id" )]
+    public Guid? BroadcastId { get; set; }
+
+    /// <summary>
+    /// Broadcast display name, present when <see cref="MetricDimension.Broadcast"/> was requested.
+    /// </summary>
+    [JsonPropertyName( "broadcast_name" )]
+    public string? BroadcastName { get; set; }
+
+    /// <summary>
+    /// Metric values for this row, keyed by metric name (for example <c>delivered</c>,
+    /// <c>opened</c>) -- the API returns these as sibling fields of the dimension keys above,
+    /// rather than nested under their own key, and the set present depends on the requested
+    /// <see cref="EmailMetricsQuery.Metrics"/>.
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> MetricValues { get; set; } = new();
+}

--- a/src/Resend/EmailMetricsQuery.cs
+++ b/src/Resend/EmailMetricsQuery.cs
@@ -1,0 +1,67 @@
+namespace Resend;
+
+/// <summary>
+/// Query parameters for <see cref="IResend.EmailMetricsAsync"/>.
+/// </summary>
+public class EmailMetricsQuery
+{
+    /// <summary>
+    /// Start of the reporting period. Defaults server-side to 6 days before <see cref="EndDate"/>.
+    /// </summary>
+    public DateTime? StartDate { get; set; }
+
+    /// <summary>
+    /// End of the reporting period. Defaults server-side to now.
+    /// </summary>
+    public DateTime? EndDate { get; set; }
+
+    /// <summary>
+    /// IANA timezone (for example <c>America/New_York</c>) used to bucket results. Defaults
+    /// server-side to <c>UTC</c>.
+    /// </summary>
+    public string? Timezone { get; set; }
+
+    /// <summary>
+    /// Bucket size used when <see cref="MetricDimension.Period"/> is one of <see cref="Dimensions"/>.
+    /// Defaults server-side to <see cref="MetricsGranularity.Daily"/>.
+    /// </summary>
+    public MetricsGranularity? Granularity { get; set; }
+
+    /// <summary>
+    /// Metrics to include in the response. Defaults server-side to all metrics.
+    /// </summary>
+    public List<MetricType>? Metrics { get; set; }
+
+    /// <summary>
+    /// Dimensions to break the results down by. Defaults server-side to none, in which case
+    /// the response carries only <see cref="EmailMetrics.Totals"/>, no <see cref="EmailMetrics.Data"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="MetricDimension.Email"/> cannot be combined with <see cref="MetricDimension.Broadcast"/>
+    /// -- the API rejects that combination with a validation error.
+    /// </remarks>
+    public List<MetricDimension>? Dimensions { get; set; }
+
+    /// <summary>
+    /// Restrict results to these sending domains. Maximum 100.
+    /// </summary>
+    public List<Guid>? DomainId { get; set; }
+
+    /// <summary>
+    /// Restrict results to these emails. Maximum 100.
+    /// </summary>
+    /// <remarks>
+    /// Cannot be combined with the <see cref="MetricDimension.Broadcast"/> dimension or
+    /// with <see cref="BroadcastId"/>.
+    /// </remarks>
+    public List<Guid>? EmailId { get; set; }
+
+    /// <summary>
+    /// Restrict results to these broadcasts. Maximum 100.
+    /// </summary>
+    /// <remarks>
+    /// Cannot be combined with the <see cref="MetricDimension.Email"/> dimension or
+    /// with <see cref="EmailId"/>.
+    /// </remarks>
+    public List<Guid>? BroadcastId { get; set; }
+}

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -206,7 +206,7 @@ public interface IResend
     /// <returns>
     /// Email metrics.
     /// </returns>
-    /// <see href="https://resend.com/docs/api-reference/emails/retrieve-email-metrics"/>
+    /// <see href="https://resend.com/docs/api-reference/emails/get-metrics"/>
     Task<ResendResponse<EmailMetrics>> EmailMetricsAsync( EmailMetricsQuery? query = null, CancellationToken cancellationToken = default );
 
     /// <summary>

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -191,6 +191,25 @@ public interface IResend
     Task<ResendResponse<EmailShareResult>> EmailShareAsync( Guid emailId, string? expiresIn = null, CancellationToken cancellationToken = default );
 
     /// <summary>
+    /// Retrieves aggregate email metrics (delivery, engagement, bounce, etc.) for a reporting
+    /// period, optionally broken down by one or more dimensions.
+    /// </summary>
+    /// <remarks>
+    /// Beta endpoint.
+    /// </remarks>
+    /// <param name="query">
+    /// Metrics query.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancellation token.
+    /// </param>
+    /// <returns>
+    /// Email metrics.
+    /// </returns>
+    /// <see href="https://resend.com/docs/api-reference/emails/retrieve-email-metrics"/>
+    Task<ResendResponse<EmailMetrics>> EmailMetricsAsync( EmailMetricsQuery? query = null, CancellationToken cancellationToken = default );
+
+    /// <summary>
     /// Lists email attachments from a sent email.
     /// </summary>
     /// <param name="emailId">Sent email identifier.</param>

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -194,9 +194,6 @@ public interface IResend
     /// Retrieves aggregate email metrics (delivery, engagement, bounce, etc.) for a reporting
     /// period, optionally broken down by one or more dimensions.
     /// </summary>
-    /// <remarks>
-    /// Beta endpoint.
-    /// </remarks>
     /// <param name="query">
     /// Metrics query.
     /// </param>

--- a/src/Resend/MetricDimension.cs
+++ b/src/Resend/MetricDimension.cs
@@ -1,0 +1,38 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// A dimension by which email metrics can be broken down.
+/// </summary>
+/// <remarks>
+/// <see cref="Email"/> cannot be combined with <see cref="Broadcast"/> -- the API rejects
+/// that combination with a validation error.
+/// </remarks>
+[JsonConverter( typeof( JsonStringEnumValueConverter<MetricDimension> ) )]
+public enum MetricDimension
+{
+    /// <summary>
+    /// Break down results into time buckets, sized per the requested granularity.
+    /// </summary>
+    [JsonStringValue( "period" )]
+    Period = 1,
+
+    /// <summary>
+    /// Break down results by sending domain.
+    /// </summary>
+    [JsonStringValue( "domain" )]
+    Domain,
+
+    /// <summary>
+    /// Break down results by individual email.
+    /// </summary>
+    [JsonStringValue( "email" )]
+    Email,
+
+    /// <summary>
+    /// Break down results by broadcast.
+    /// </summary>
+    [JsonStringValue( "broadcast" )]
+    Broadcast,
+}

--- a/src/Resend/MetricType.cs
+++ b/src/Resend/MetricType.cs
@@ -1,0 +1,142 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// A metric that can be requested from <see cref="IResend.EmailMetricsAsync"/>.
+/// </summary>
+[JsonConverter( typeof( JsonStringEnumValueConverter<MetricType> ) )]
+public enum MetricType
+{
+    /// <summary>
+    /// Number of emails received/accepted for sending.
+    /// </summary>
+    [JsonStringValue( "received" )]
+    Received = 1,
+
+    /// <summary>
+    /// Number of emails delivered to the recipient's mail server.
+    /// </summary>
+    [JsonStringValue( "delivered" )]
+    Delivered,
+
+    /// <summary>
+    /// Number of emails the recipient marked as spam.
+    /// </summary>
+    [JsonStringValue( "complained" )]
+    Complained,
+
+    /// <summary>
+    /// Number of emails suppressed instead of being sent.
+    /// </summary>
+    [JsonStringValue( "suppressed" )]
+    Suppressed,
+
+    /// <summary>
+    /// Number of emails that bounced, of any kind.
+    /// </summary>
+    [JsonStringValue( "bounced" )]
+    Bounced,
+
+    /// <summary>
+    /// Number of emails that bounced transiently (may succeed on retry).
+    /// </summary>
+    [JsonStringValue( "bounced_transient" )]
+    BouncedTransient,
+
+    /// <summary>
+    /// Number of emails that bounced permanently.
+    /// </summary>
+    [JsonStringValue( "bounced_permanent" )]
+    BouncedPermanent,
+
+    /// <summary>
+    /// Number of emails that bounced for an undetermined reason.
+    /// </summary>
+    [JsonStringValue( "bounced_undetermined" )]
+    BouncedUndetermined,
+
+    /// <summary>
+    /// Number of emails opened by the recipient.
+    /// </summary>
+    [JsonStringValue( "opened" )]
+    Opened,
+
+    /// <summary>
+    /// Number of emails whose links were clicked by the recipient.
+    /// </summary>
+    [JsonStringValue( "clicked" )]
+    Clicked,
+
+    /// <summary>
+    /// Number of recipients who unsubscribed.
+    /// </summary>
+    [JsonStringValue( "unsubscribed" )]
+    Unsubscribed,
+
+    /// <summary>
+    /// Number of emails whose delivery was delayed.
+    /// </summary>
+    [JsonStringValue( "delivery_delayed" )]
+    DeliveryDelayed,
+
+    /// <summary>
+    /// Number of emails that failed to send.
+    /// </summary>
+    [JsonStringValue( "failed" )]
+    Failed,
+
+    /// <summary>
+    /// Number of emails sent.
+    /// </summary>
+    [JsonStringValue( "sent" )]
+    Sent,
+
+    /// <summary>
+    /// Number of unique recipients who opened an email.
+    /// </summary>
+    [JsonStringValue( "unique_opened" )]
+    UniqueOpened,
+
+    /// <summary>
+    /// Number of unique recipients who clicked a link.
+    /// </summary>
+    [JsonStringValue( "unique_clicked" )]
+    UniqueClicked,
+
+    /// <summary>
+    /// Delivered / sent, as a fraction.
+    /// </summary>
+    [JsonStringValue( "delivery_rate" )]
+    DeliveryRate,
+
+    /// <summary>
+    /// Unique opens / delivered, as a fraction.
+    /// </summary>
+    [JsonStringValue( "open_rate" )]
+    OpenRate,
+
+    /// <summary>
+    /// Unique clicks / delivered, as a fraction.
+    /// </summary>
+    [JsonStringValue( "click_rate" )]
+    ClickRate,
+
+    /// <summary>
+    /// Bounced / sent, as a fraction.
+    /// </summary>
+    [JsonStringValue( "bounce_rate" )]
+    BounceRate,
+
+    /// <summary>
+    /// Complained / delivered, as a fraction.
+    /// </summary>
+    [JsonStringValue( "complaint_rate" )]
+    ComplaintRate,
+
+    /// <summary>
+    /// Unsubscribed / delivered, as a fraction.
+    /// </summary>
+    [JsonStringValue( "unsubscribe_rate" )]
+    UnsubscribeRate,
+}

--- a/src/Resend/MetricsGranularity.cs
+++ b/src/Resend/MetricsGranularity.cs
@@ -1,0 +1,35 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// Bucket size used to group metrics data points when <see cref="MetricDimension.Period"/>
+/// is one of the requested dimensions.
+/// </summary>
+[JsonConverter( typeof( JsonStringEnumValueConverter<MetricsGranularity> ) )]
+public enum MetricsGranularity
+{
+    /// <summary>
+    /// One data point per hour.
+    /// </summary>
+    [JsonStringValue( "hourly" )]
+    Hourly = 1,
+
+    /// <summary>
+    /// One data point per day.
+    /// </summary>
+    [JsonStringValue( "daily" )]
+    Daily,
+
+    /// <summary>
+    /// One data point per week.
+    /// </summary>
+    [JsonStringValue( "weekly" )]
+    Weekly,
+
+    /// <summary>
+    /// One data point per month.
+    /// </summary>
+    [JsonStringValue( "monthly" )]
+    Monthly,
+}

--- a/src/Resend/ResendClient.cs
+++ b/src/Resend/ResendClient.cs
@@ -230,6 +230,52 @@ public partial class ResendClient : IResend
 
 
     /// <inheritdoc />
+    public Task<ResendResponse<EmailMetrics>> EmailMetricsAsync( EmailMetricsQuery? query = null, CancellationToken cancellationToken = default )
+    {
+        var baseUrl = "/emails/metrics";
+        var url = baseUrl;
+
+        if ( query != null )
+        {
+            var qs = new Dictionary<string, string?>();
+
+            if ( query.StartDate.HasValue == true )
+                qs.Add( "start_date", query.StartDate.Value.ToUniversalTime().ToString( "o" ) );
+
+            if ( query.EndDate.HasValue == true )
+                qs.Add( "end_date", query.EndDate.Value.ToUniversalTime().ToString( "o" ) );
+
+            if ( query.Timezone != null )
+                qs.Add( "timezone", query.Timezone );
+
+            if ( query.Granularity.HasValue == true )
+                qs.Add( "granularity", JsonStringEnumValue<MetricsGranularity>.Of( query.Granularity.Value ) );
+
+            if ( query.Metrics?.Count > 0 )
+                qs.Add( "metrics", string.Join( ",", query.Metrics.Select( x => JsonStringEnumValue<MetricType>.Of( x ) ) ) );
+
+            if ( query.Dimensions?.Count > 0 )
+                qs.Add( "dimensions", string.Join( ",", query.Dimensions.Select( x => JsonStringEnumValue<MetricDimension>.Of( x ) ) ) );
+
+            if ( query.DomainId?.Count > 0 )
+                qs.Add( "domain_id", string.Join( ",", query.DomainId ) );
+
+            if ( query.EmailId?.Count > 0 )
+                qs.Add( "email_id", string.Join( ",", query.EmailId ) );
+
+            if ( query.BroadcastId?.Count > 0 )
+                qs.Add( "broadcast_id", string.Join( ",", query.BroadcastId ) );
+
+            url = QueryHelpers.AddQueryString( baseUrl, qs );
+        }
+
+        var req = new HttpRequestMessage( HttpMethod.Get, url );
+
+        return Execute<EmailMetrics, EmailMetrics>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
     public Task<ResendResponse<Domain>> DomainAddAsync( string domainName, DeliveryRegion? region = null, CancellationToken cancellationToken = default )
     {
         var path = $"/domains";

--- a/src/Resend/ResendClient.cs
+++ b/src/Resend/ResendClient.cs
@@ -240,10 +240,10 @@ public partial class ResendClient : IResend
             var qs = new Dictionary<string, string?>();
 
             if ( query.StartDate.HasValue == true )
-                qs.Add( "start_date", query.StartDate.Value.ToUniversalTime().ToString( "o" ) );
+                qs.Add( "start_date", ToUtcQueryValue( query.StartDate.Value ) );
 
             if ( query.EndDate.HasValue == true )
-                qs.Add( "end_date", query.EndDate.Value.ToUniversalTime().ToString( "o" ) );
+                qs.Add( "end_date", ToUtcQueryValue( query.EndDate.Value ) );
 
             if ( query.Timezone != null )
                 qs.Add( "timezone", query.Timezone );
@@ -272,6 +272,12 @@ public partial class ResendClient : IResend
         var req = new HttpRequestMessage( HttpMethod.Get, url );
 
         return Execute<EmailMetrics, EmailMetrics>( req, ( x ) => x, cancellationToken );
+    }
+
+    private static string ToUtcQueryValue( DateTime value )
+    {
+        var utc = value.Kind == DateTimeKind.Unspecified ? DateTime.SpecifyKind( value, DateTimeKind.Utc ) : value.ToUniversalTime();
+        return utc.ToString( "o" );
     }
 
 

--- a/tests/Resend.Tests/ResendClientTests.Metrics.cs
+++ b/tests/Resend.Tests/ResendClientTests.Metrics.cs
@@ -1,3 +1,5 @@
+using System.Net;
+
 namespace Resend.Tests;
 
 /// <summary />
@@ -251,5 +253,58 @@ public partial class ResendClientTests
         Assert.Equal( 2, resp.Content.Totals.Count );
         Assert.True( resp.Content.Totals.ContainsKey( "delivered" ) );
         Assert.True( resp.Content.Totals.ContainsKey( "opened" ) );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task EmailMetricsRejectsEmailAndBroadcastDimensionsCombined()
+    {
+        var ex = await Assert.ThrowsAsync<ResendException>( () => _resend.EmailMetricsAsync( new EmailMetricsQuery()
+        {
+            Dimensions = new List<MetricDimension>() { MetricDimension.Email, MetricDimension.Broadcast },
+        } ) );
+
+        Assert.Equal( HttpStatusCode.BadRequest, ex.StatusCode );
+        Assert.Equal( ErrorType.ValidationError, ex.ErrorType );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task EmailMetricsRejectsEmailDimensionWithBroadcastIdFilter()
+    {
+        var ex = await Assert.ThrowsAsync<ResendException>( () => _resend.EmailMetricsAsync( new EmailMetricsQuery()
+        {
+            Dimensions = new List<MetricDimension>() { MetricDimension.Email },
+            BroadcastId = new List<Guid>() { Guid.NewGuid() },
+        } ) );
+
+        Assert.Equal( HttpStatusCode.BadRequest, ex.StatusCode );
+        Assert.Equal( ErrorType.ValidationError, ex.ErrorType );
+    }
+
+
+    /// <summary>
+    /// A `Kind.Unspecified` value (e.g. from `new DateTime(...)`) must be sent as-is in UTC,
+    /// not reinterpreted using the host machine's local offset.
+    /// </summary>
+    [Fact]
+    public async Task EmailMetricsTreatsUnspecifiedKindDateTimeAsUtc()
+    {
+        var start = new DateTime( 2026, 7, 1, 0, 0, 0, DateTimeKind.Unspecified );
+        var end = new DateTime( 2026, 7, 8, 0, 0, 0, DateTimeKind.Unspecified );
+
+        var resp = await _resend.EmailMetricsAsync( new EmailMetricsQuery()
+        {
+            StartDate = start,
+            EndDate = end,
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( start, resp.Content.StartDate );
+        Assert.Equal( end, resp.Content.EndDate );
     }
 }

--- a/tests/Resend.Tests/ResendClientTests.Metrics.cs
+++ b/tests/Resend.Tests/ResendClientTests.Metrics.cs
@@ -266,7 +266,7 @@ public partial class ResendClientTests
             Dimensions = new List<MetricDimension>() { MetricDimension.Email, MetricDimension.Broadcast },
         } ) );
 
-        Assert.Equal( HttpStatusCode.BadRequest, ex.StatusCode );
+        Assert.Equal( HttpStatusCode.UnprocessableEntity, ex.StatusCode );
         Assert.Equal( ErrorType.ValidationError, ex.ErrorType );
     }
 
@@ -281,7 +281,7 @@ public partial class ResendClientTests
             BroadcastId = new List<Guid>() { Guid.NewGuid() },
         } ) );
 
-        Assert.Equal( HttpStatusCode.BadRequest, ex.StatusCode );
+        Assert.Equal( HttpStatusCode.UnprocessableEntity, ex.StatusCode );
         Assert.Equal( ErrorType.ValidationError, ex.ErrorType );
     }
 

--- a/tests/Resend.Tests/ResendClientTests.Metrics.cs
+++ b/tests/Resend.Tests/ResendClientTests.Metrics.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text;
 
 namespace Resend.Tests;
 
@@ -287,24 +288,55 @@ public partial class ResendClientTests
 
     /// <summary>
     /// A `Kind.Unspecified` value (e.g. from `new DateTime(...)`) must be sent as-is in UTC,
-    /// not reinterpreted using the host machine's local offset.
+    /// not reinterpreted using the host machine's local offset. Asserts on the literal query
+    /// string that was actually sent, rather than round-tripping the value through the fake
+    /// server, so this targets the client's own serialization directly instead of picking up
+    /// the fake server's parsing behavior along the way. Note this still can't distinguish
+    /// the fix from the regression it guards against on a host whose local timezone is
+    /// exactly UTC, since `ToUniversalTime()` on an `Unspecified` value is a no-op there
+    /// either way — that's inherent to the bug shape, not something any assertion can fix.
     /// </summary>
     [Fact]
     public async Task EmailMetricsTreatsUnspecifiedKindDateTimeAsUtc()
     {
+        var handler = new RecordingHandler();
+        var resend = ResendClient.Create( new ResendClientOptions() { ApiToken = "re_test_123" }, new HttpClient( handler ) );
+
         var start = new DateTime( 2026, 7, 1, 0, 0, 0, DateTimeKind.Unspecified );
         var end = new DateTime( 2026, 7, 8, 0, 0, 0, DateTimeKind.Unspecified );
 
-        var resp = await _resend.EmailMetricsAsync( new EmailMetricsQuery()
+        await resend.EmailMetricsAsync( new EmailMetricsQuery()
         {
             StartDate = start,
             EndDate = end,
         } );
 
-        Assert.NotNull( resp );
-        Assert.True( resp.Success );
-        Assert.NotNull( resp.Content );
-        Assert.Equal( start, resp.Content.StartDate );
-        Assert.Equal( end, resp.Content.EndDate );
+        var req = Assert.Single( handler.Requests );
+        var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery( req.RequestUri!.Query );
+        Assert.Equal( "2026-07-01T00:00:00.0000000Z", query["start_date"].ToString() );
+        Assert.Equal( "2026-07-08T00:00:00.0000000Z", query["end_date"].ToString() );
+    }
+
+
+    /// <summary />
+    private class RecordingHandler : HttpMessageHandler
+    {
+        /// <summary />
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+
+        /// <inheritdoc />
+        protected override Task<HttpResponseMessage> SendAsync( HttpRequestMessage request, CancellationToken cancellationToken )
+        {
+            Requests.Add( request );
+
+            var resp = new HttpResponseMessage( HttpStatusCode.OK );
+            resp.Content = new StringContent(
+                """{"object":"metrics","start_date":"2026-07-01T00:00:00Z","end_date":"2026-07-08T00:00:00Z","metrics":[],"dimensions":[],"granularity":"daily","totals":{}}""",
+                Encoding.UTF8,
+                "application/json" );
+
+            return Task.FromResult( resp );
+        }
     }
 }

--- a/tests/Resend.Tests/ResendClientTests.Metrics.cs
+++ b/tests/Resend.Tests/ResendClientTests.Metrics.cs
@@ -1,0 +1,255 @@
+namespace Resend.Tests;
+
+/// <summary />
+public partial class ResendClientTests
+{
+    /// <summary />
+    [Fact]
+    public async Task EmailMetricsDefault()
+    {
+        var resp = await _resend.EmailMetricsAsync();
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( "metrics", resp.Content.Object );
+        Assert.Equal( MetricsGranularity.Daily, resp.Content.Granularity );
+        Assert.Empty( resp.Content.Dimensions );
+        Assert.Null( resp.Content.Data );
+        Assert.Equal( Enum.GetValues<MetricType>().Length, resp.Content.Metrics.Count );
+        Assert.Equal( Enum.GetValues<MetricType>().Length, resp.Content.Totals.Count );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task EmailMetricsByDimensionPeriod()
+    {
+        var resp = await _resend.EmailMetricsAsync( new EmailMetricsQuery()
+        {
+            Dimensions = new List<MetricDimension>() { MetricDimension.Period },
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( new[] { MetricDimension.Period }, resp.Content.Dimensions );
+        Assert.NotNull( resp.Content.Data );
+        Assert.Single( resp.Content.Data );
+        Assert.NotNull( resp.Content.Data[ 0 ].Period );
+        Assert.Null( resp.Content.Data[ 0 ].DomainId );
+        Assert.Null( resp.Content.Data[ 0 ].EmailId );
+        Assert.Null( resp.Content.Data[ 0 ].BroadcastId );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task EmailMetricsByDimensionDomain()
+    {
+        var resp = await _resend.EmailMetricsAsync( new EmailMetricsQuery()
+        {
+            Dimensions = new List<MetricDimension>() { MetricDimension.Domain },
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( new[] { MetricDimension.Domain }, resp.Content.Dimensions );
+        Assert.NotNull( resp.Content.Data );
+        Assert.Single( resp.Content.Data );
+        Assert.NotNull( resp.Content.Data[ 0 ].DomainId );
+        Assert.Equal( "example.com", resp.Content.Data[ 0 ].DomainName );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task EmailMetricsByDimensionEmail()
+    {
+        var resp = await _resend.EmailMetricsAsync( new EmailMetricsQuery()
+        {
+            Dimensions = new List<MetricDimension>() { MetricDimension.Email },
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( new[] { MetricDimension.Email }, resp.Content.Dimensions );
+        Assert.NotNull( resp.Content.Data );
+        Assert.Single( resp.Content.Data );
+        Assert.NotNull( resp.Content.Data[ 0 ].EmailId );
+    }
+
+
+    /// <summary />
+    [Fact]
+    public async Task EmailMetricsByDimensionBroadcast()
+    {
+        var resp = await _resend.EmailMetricsAsync( new EmailMetricsQuery()
+        {
+            Dimensions = new List<MetricDimension>() { MetricDimension.Broadcast },
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( new[] { MetricDimension.Broadcast }, resp.Content.Dimensions );
+        Assert.NotNull( resp.Content.Data );
+        Assert.Single( resp.Content.Data );
+        Assert.NotNull( resp.Content.Data[ 0 ].BroadcastId );
+        Assert.Equal( "July Newsletter", resp.Content.Data[ 0 ].BroadcastName );
+    }
+
+
+    /// <summary>
+    /// Single-value filters must reach the API in the `domain_id` query parameter.
+    /// </summary>
+    [Fact]
+    public async Task EmailMetricsFilterByDomainIdSingle()
+    {
+        var domainId = Guid.NewGuid();
+
+        var resp = await _resend.EmailMetricsAsync( new EmailMetricsQuery()
+        {
+            Dimensions = new List<MetricDimension>() { MetricDimension.Domain },
+            DomainId = new List<Guid>() { domainId },
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( domainId, resp.Content.Data![ 0 ].DomainId );
+    }
+
+
+    /// <summary>
+    /// Multiple filter values must be comma-joined into a single `domain_id` query parameter.
+    /// </summary>
+    [Fact]
+    public async Task EmailMetricsFilterByDomainIdMultiple()
+    {
+        var domainIds = new List<Guid>() { Guid.NewGuid(), Guid.NewGuid() };
+
+        var resp = await _resend.EmailMetricsAsync( new EmailMetricsQuery()
+        {
+            Dimensions = new List<MetricDimension>() { MetricDimension.Domain },
+            DomainId = domainIds,
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( domainIds[ 0 ], resp.Content.Data![ 0 ].DomainId );
+    }
+
+
+    /// <summary>
+    /// Single-value filters must reach the API in the `email_id` query parameter.
+    /// </summary>
+    [Fact]
+    public async Task EmailMetricsFilterByEmailIdSingle()
+    {
+        var emailId = Guid.NewGuid();
+
+        var resp = await _resend.EmailMetricsAsync( new EmailMetricsQuery()
+        {
+            Dimensions = new List<MetricDimension>() { MetricDimension.Email },
+            EmailId = new List<Guid>() { emailId },
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( emailId, resp.Content.Data![ 0 ].EmailId );
+    }
+
+
+    /// <summary>
+    /// Multiple filter values must be comma-joined into a single `email_id` query parameter.
+    /// </summary>
+    [Fact]
+    public async Task EmailMetricsFilterByEmailIdMultiple()
+    {
+        var emailIds = new List<Guid>() { Guid.NewGuid(), Guid.NewGuid() };
+
+        var resp = await _resend.EmailMetricsAsync( new EmailMetricsQuery()
+        {
+            Dimensions = new List<MetricDimension>() { MetricDimension.Email },
+            EmailId = emailIds,
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( emailIds[ 0 ], resp.Content.Data![ 0 ].EmailId );
+    }
+
+
+    /// <summary>
+    /// Single-value filters must reach the API in the `broadcast_id` query parameter.
+    /// </summary>
+    [Fact]
+    public async Task EmailMetricsFilterByBroadcastIdSingle()
+    {
+        var broadcastId = Guid.NewGuid();
+
+        var resp = await _resend.EmailMetricsAsync( new EmailMetricsQuery()
+        {
+            Dimensions = new List<MetricDimension>() { MetricDimension.Broadcast },
+            BroadcastId = new List<Guid>() { broadcastId },
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( broadcastId, resp.Content.Data![ 0 ].BroadcastId );
+    }
+
+
+    /// <summary>
+    /// Multiple filter values must be comma-joined into a single `broadcast_id` query parameter.
+    /// </summary>
+    [Fact]
+    public async Task EmailMetricsFilterByBroadcastIdMultiple()
+    {
+        var broadcastIds = new List<Guid>() { Guid.NewGuid(), Guid.NewGuid() };
+
+        var resp = await _resend.EmailMetricsAsync( new EmailMetricsQuery()
+        {
+            Dimensions = new List<MetricDimension>() { MetricDimension.Broadcast },
+            BroadcastId = broadcastIds,
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( broadcastIds[ 0 ], resp.Content.Data![ 0 ].BroadcastId );
+    }
+
+
+    /// <summary>
+    /// `metrics` and `granularity` are echoed back by the API and can be asserted on directly;
+    /// `timezone` isn't part of the response shape, so this only proves the request round-trips
+    /// successfully with it set.
+    /// </summary>
+    [Fact]
+    public async Task EmailMetricsWithMetricsGranularityAndTimezone()
+    {
+        var resp = await _resend.EmailMetricsAsync( new EmailMetricsQuery()
+        {
+            Metrics = new List<MetricType>() { MetricType.Delivered, MetricType.Opened },
+            Granularity = MetricsGranularity.Hourly,
+            Timezone = "America/New_York",
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( new[] { MetricType.Delivered, MetricType.Opened }, resp.Content.Metrics );
+        Assert.Equal( MetricsGranularity.Hourly, resp.Content.Granularity );
+        Assert.Equal( 2, resp.Content.Totals.Count );
+        Assert.True( resp.Content.Totals.ContainsKey( "delivered" ) );
+        Assert.True( resp.Content.Totals.ContainsKey( "opened" ) );
+    }
+}

--- a/tools/Resend.ApiServer/Controllers/EmailController.cs
+++ b/tools/Resend.ApiServer/Controllers/EmailController.cs
@@ -254,9 +254,9 @@ public class EmailController : ControllerBase
 
         if ( hasEmail && hasBroadcast )
         {
-            return BadRequest( new ErrorResponse()
+            return UnprocessableEntity( new ErrorResponse()
             {
-                StatusCode = (int) HttpStatusCode.BadRequest,
+                StatusCode = (int) HttpStatusCode.UnprocessableEntity,
                 ErrorType = ErrorType.ValidationError,
                 Message = "The `broadcast` dimension/`broadcast_id` filter cannot be combined with the `email` dimension/`email_id` filter.",
             } );

--- a/tools/Resend.ApiServer/Controllers/EmailController.cs
+++ b/tools/Resend.ApiServer/Controllers/EmailController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Resend.Payloads;
 using System.Net;
+using System.Text.Json;
 
 namespace Resend.ApiServer.Controllers;
 
@@ -222,8 +223,177 @@ public class EmailController : ControllerBase
     }
 
 
+    /// <summary>
+    /// Fakes the beta metrics endpoint, echoing back the request's shape (granularity,
+    /// requested metrics/dimensions, filters) so tests can assert on how the SDK built the query.
+    /// </summary>
+    [HttpGet]
+    [Route( "emails/metrics" )]
+    public EmailMetrics EmailMetrics(
+        [FromQuery( Name = "start_date" )] string? startDate,
+        [FromQuery( Name = "end_date" )] string? endDate,
+        [FromQuery( Name = "timezone" )] string? timezone,
+        [FromQuery( Name = "granularity" )] string? granularity,
+        [FromQuery( Name = "metrics" )] string? metrics,
+        [FromQuery( Name = "dimensions" )] string? dimensions,
+        [FromQuery( Name = "domain_id" )] string? domainId,
+        [FromQuery( Name = "email_id" )] string? emailId,
+        [FromQuery( Name = "broadcast_id" )] string? broadcastId
+    )
+    {
+        _logger.LogDebug( "EmailMetrics" );
+
+        var end = string.IsNullOrEmpty( endDate ) == false ? DateTime.Parse( endDate ).ToUniversalTime() : DateTime.UtcNow;
+        var start = string.IsNullOrEmpty( startDate ) == false ? DateTime.Parse( startDate ).ToUniversalTime() : end.AddDays( -6 );
+
+        var metricNames = SplitCsv( metrics ) ?? AllMetricNames;
+        var dimensionNames = SplitCsv( dimensions ) ?? new List<string>();
+
+        var result = new EmailMetrics()
+        {
+            Object = "metrics",
+            StartDate = start,
+            EndDate = end,
+            Metrics = metricNames.Select( ParseMetricType ).ToList(),
+            Dimensions = dimensionNames.Select( ParseMetricDimension ).ToList(),
+            Granularity = granularity switch
+            {
+                "hourly" => MetricsGranularity.Hourly,
+                "weekly" => MetricsGranularity.Weekly,
+                "monthly" => MetricsGranularity.Monthly,
+                _ => MetricsGranularity.Daily,
+            },
+            Totals = metricNames.ToDictionary( x => x, x => 10d ),
+        };
+
+        if ( dimensionNames.Count > 0 )
+        {
+            var row = new EmailMetricsDataPoint();
+
+            if ( dimensionNames.Contains( "period" ) == true )
+                row.Period = start.ToString( "yyyy-MM-dd" );
+
+            if ( dimensionNames.Contains( "domain" ) == true )
+            {
+                row.DomainId = SplitCsv( domainId )?.Select( Guid.Parse ).FirstOrDefault() ?? Guid.NewGuid();
+                row.DomainName = "example.com";
+            }
+
+            if ( dimensionNames.Contains( "email" ) == true )
+                row.EmailId = SplitCsv( emailId )?.Select( Guid.Parse ).FirstOrDefault() ?? Guid.NewGuid();
+
+            if ( dimensionNames.Contains( "broadcast" ) == true )
+            {
+                row.BroadcastId = SplitCsv( broadcastId )?.Select( Guid.Parse ).FirstOrDefault() ?? Guid.NewGuid();
+                row.BroadcastName = "July Newsletter";
+            }
+
+            foreach ( var name in metricNames )
+                row.MetricValues[ name ] = JsonSerializer.SerializeToElement( 10d );
+
+            result.Data = new List<EmailMetricsDataPoint>() { row };
+        }
+
+        return result;
+    }
+
+
+    /// <summary />
+    private static readonly List<string> AllMetricNames = Enum.GetValues<MetricType>()
+        .Select( ParseableName )
+        .ToList();
+
+
+    /// <summary />
+    private static List<string>? SplitCsv( string? value )
+    {
+        if ( string.IsNullOrWhiteSpace( value ) == true )
+            return null;
+
+        return value.Split( ',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries ).ToList();
+    }
+
+
+    /// <summary />
+    private static string ParseableName( MetricType value )
+    {
+        return value switch
+        {
+            MetricType.Received => "received",
+            MetricType.Delivered => "delivered",
+            MetricType.Complained => "complained",
+            MetricType.Suppressed => "suppressed",
+            MetricType.Bounced => "bounced",
+            MetricType.BouncedTransient => "bounced_transient",
+            MetricType.BouncedPermanent => "bounced_permanent",
+            MetricType.BouncedUndetermined => "bounced_undetermined",
+            MetricType.Opened => "opened",
+            MetricType.Clicked => "clicked",
+            MetricType.Unsubscribed => "unsubscribed",
+            MetricType.DeliveryDelayed => "delivery_delayed",
+            MetricType.Failed => "failed",
+            MetricType.Sent => "sent",
+            MetricType.UniqueOpened => "unique_opened",
+            MetricType.UniqueClicked => "unique_clicked",
+            MetricType.DeliveryRate => "delivery_rate",
+            MetricType.OpenRate => "open_rate",
+            MetricType.ClickRate => "click_rate",
+            MetricType.BounceRate => "bounce_rate",
+            MetricType.ComplaintRate => "complaint_rate",
+            MetricType.UnsubscribeRate => "unsubscribe_rate",
+            _ => throw new NotImplementedException( $"Unmapped metric type: {value}" ),
+        };
+    }
+
+
     private static readonly HashSet<string> ValidExpiresIn = new( StringComparer.OrdinalIgnoreCase )
     {
         "48h", "10m", "2 hours", "1 day", "1h 30m",
     };
+
+
+    /// <summary />
+    private static MetricType ParseMetricType( string value )
+    {
+        return value switch
+        {
+            "received" => MetricType.Received,
+            "delivered" => MetricType.Delivered,
+            "complained" => MetricType.Complained,
+            "suppressed" => MetricType.Suppressed,
+            "bounced" => MetricType.Bounced,
+            "bounced_transient" => MetricType.BouncedTransient,
+            "bounced_permanent" => MetricType.BouncedPermanent,
+            "bounced_undetermined" => MetricType.BouncedUndetermined,
+            "opened" => MetricType.Opened,
+            "clicked" => MetricType.Clicked,
+            "unsubscribed" => MetricType.Unsubscribed,
+            "delivery_delayed" => MetricType.DeliveryDelayed,
+            "failed" => MetricType.Failed,
+            "sent" => MetricType.Sent,
+            "unique_opened" => MetricType.UniqueOpened,
+            "unique_clicked" => MetricType.UniqueClicked,
+            "delivery_rate" => MetricType.DeliveryRate,
+            "open_rate" => MetricType.OpenRate,
+            "click_rate" => MetricType.ClickRate,
+            "bounce_rate" => MetricType.BounceRate,
+            "complaint_rate" => MetricType.ComplaintRate,
+            "unsubscribe_rate" => MetricType.UnsubscribeRate,
+            _ => throw new ArgumentOutOfRangeException( nameof( value ), $"Unknown metric: '{value}'" ),
+        };
+    }
+
+
+    /// <summary />
+    private static MetricDimension ParseMetricDimension( string value )
+    {
+        return value switch
+        {
+            "period" => MetricDimension.Period,
+            "domain" => MetricDimension.Domain,
+            "email" => MetricDimension.Email,
+            "broadcast" => MetricDimension.Broadcast,
+            _ => throw new ArgumentOutOfRangeException( nameof( value ), $"Unknown dimension: '{value}'" ),
+        };
+    }
 }

--- a/tools/Resend.ApiServer/Controllers/EmailController.cs
+++ b/tools/Resend.ApiServer/Controllers/EmailController.cs
@@ -224,12 +224,12 @@ public class EmailController : ControllerBase
 
 
     /// <summary>
-    /// Fakes the beta metrics endpoint, echoing back the request's shape (granularity,
+    /// Fakes the metrics endpoint, echoing back the request's shape (granularity,
     /// requested metrics/dimensions, filters) so tests can assert on how the SDK built the query.
     /// </summary>
     [HttpGet]
     [Route( "emails/metrics" )]
-    public EmailMetrics EmailMetrics(
+    public ActionResult<EmailMetrics> EmailMetrics(
         [FromQuery( Name = "start_date" )] string? startDate,
         [FromQuery( Name = "end_date" )] string? endDate,
         [FromQuery( Name = "timezone" )] string? timezone,
@@ -248,6 +248,19 @@ public class EmailController : ControllerBase
 
         var metricNames = SplitCsv( metrics ) ?? AllMetricNames;
         var dimensionNames = SplitCsv( dimensions ) ?? new List<string>();
+
+        var hasEmail = dimensionNames.Contains( "email" ) || string.IsNullOrEmpty( emailId ) == false;
+        var hasBroadcast = dimensionNames.Contains( "broadcast" ) || string.IsNullOrEmpty( broadcastId ) == false;
+
+        if ( hasEmail && hasBroadcast )
+        {
+            return BadRequest( new ErrorResponse()
+            {
+                StatusCode = (int) HttpStatusCode.BadRequest,
+                ErrorType = ErrorType.ValidationError,
+                Message = "The `broadcast` dimension/`broadcast_id` filter cannot be combined with the `email` dimension/`email_id` filter.",
+            } );
+        }
 
         var result = new EmailMetrics()
         {


### PR DESCRIPTION
Adds `EmailMetricsAsync` for account-level email metrics via `GET /emails/metrics` — `period`/`domain`/`email`/`broadcast` dimensions, `domain_id`/`email_id`/`broadcast_id` filters (`broadcast` and `email` mutually exclusive), `hourly`/`daily`/`weekly`/`monthly` granularity.

Mirrors https://github.com/resend/resend-node/pull/1079. Spec: https://github.com/resend/resend-openapi/pull/96