### PR TITLE
feat: add BroadcastClickedLinksAsync() method

### DIFF
--- a/src/Resend/BroadcastClickedLink.cs
+++ b/src/Resend/BroadcastClickedLink.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// A single clicked link in a broadcast clicked-links list response.
+/// </summary>
+public class BroadcastClickedLink
+{
+    /// <summary>
+    /// An opaque cursor for this row, used only for pagination.
+    /// It does not identify any entity in Resend.
+    /// </summary>
+    [JsonPropertyName( "id" )]
+    public string Id { get; set; } = default!;
+
+    /// <summary>
+    /// The URL that was clicked.
+    /// </summary>
+    [JsonPropertyName( "url" )]
+    public string Url { get; set; } = default!;
+
+    /// <summary>
+    /// Total number of clicks on this URL.
+    /// </summary>
+    [JsonPropertyName( "clicks" )]
+    public int Clicks { get; set; }
+
+    /// <summary>
+    /// Number of unique clicks on this URL.
+    /// </summary>
+    [JsonPropertyName( "unique_clicks" )]
+    public int UniqueClicks { get; set; }
+}

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -853,6 +853,15 @@ public interface IResend
     /// <returns>Response.</returns>
     Task<ResendResponse> BroadcastDeleteAsync( Guid broadcastId, CancellationToken cancellationToken = default );
 
+    /// <summary>
+    /// Lists the links clicked in a broadcast.
+    /// </summary>
+    /// <param name="broadcastId">Broadcast identifier.</param>
+    /// <param name="query">Pagination query.</param>
+    /// <param name="cancellationToken">Cancelation token.</param>
+    /// <returns>Page of clicked links.</returns>
+    Task<ResendResponse<PaginatedResult<BroadcastClickedLink>>> BroadcastClickedLinksAsync( Guid broadcastId, PaginatedQuery? query = null, CancellationToken cancellationToken = default );
+
     #endregion
 
     #region Receiving

--- a/src/Resend/ResendClient.cs
+++ b/src/Resend/ResendClient.cs
@@ -489,6 +489,34 @@ public partial class ResendClient : IResend
     }
 
 
+    /// <inheritdoc/>
+    public Task<ResendResponse<PaginatedResult<BroadcastClickedLink>>> BroadcastClickedLinksAsync( Guid broadcastId, PaginatedQuery? query = null, CancellationToken cancellationToken = default )
+    {
+        var baseUrl = $"/broadcasts/{broadcastId}/clicked-links";
+        var url = baseUrl;
+
+        if ( query != null )
+        {
+            var qs = new Dictionary<string, string?>();
+
+            if ( query.Limit.HasValue == true )
+                qs.Add( "limit", query.Limit.Value.ToString() );
+
+            if ( query.Before != null )
+                qs.Add( "before", query.Before );
+
+            if ( query.After != null )
+                qs.Add( "after", query.After );
+
+            url = QueryHelpers.AddQueryString( baseUrl, qs );
+        }
+
+        var req = new HttpRequestMessage( HttpMethod.Get, url );
+
+        return Execute<PaginatedResult<BroadcastClickedLink>, PaginatedResult<BroadcastClickedLink>>( req, ( x ) => x, cancellationToken );
+    }
+
+
     /// <summary />
     private async Task<ResendResponse> Execute( HttpRequestMessage req, CancellationToken cancellationToken )
     {

--- a/tests/Resend.Tests/ResendClientTests.cs
+++ b/tests/Resend.Tests/ResendClientTests.cs
@@ -499,4 +499,39 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
 
         Assert.NotNull( resp );
     }
+
+
+    /// <summary/>
+    [Fact]
+    public async Task BroadcastClickedLinks()
+    {
+        var broadcastId = Guid.NewGuid();
+
+        var resp = await _resend.BroadcastClickedLinksAsync( broadcastId );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.False( resp.Content.HasMore );
+        Assert.Equal( 2, resp.Content.Data.Count );
+        Assert.Equal( "https://resend.com/pricing", resp.Content.Data[ 0 ].Url );
+        Assert.Equal( 42, resp.Content.Data[ 0 ].Clicks );
+        Assert.Equal( 30, resp.Content.Data[ 0 ].UniqueClicks );
+    }
+
+
+    /// <summary/>
+    [Fact]
+    public async Task BroadcastClickedLinks_WithQuery()
+    {
+        var broadcastId = Guid.NewGuid();
+
+        var resp = await _resend.BroadcastClickedLinksAsync( broadcastId, new PaginatedQuery()
+        {
+            Limit = 10,
+            After = "cursor-value",
+        } );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+    }
 }

--- a/tools/Resend.ApiServer/Controllers/BroadcastController.cs
+++ b/tools/Resend.ApiServer/Controllers/BroadcastController.cs
@@ -144,4 +144,40 @@ public class BroadcastController : ControllerBase
             Data = list,
         };
     }
+
+
+    /// <summary />
+    [HttpGet]
+    [Route( "broadcasts/{broadcastId}/clicked-links" )]
+    public PaginatedResult<BroadcastClickedLink> BroadcastClickedLinks(
+        [FromRoute] Guid broadcastId,
+        [FromQuery] string? limit = null,
+        [FromQuery] string? before = null,
+        [FromQuery] string? after = null
+    )
+    {
+        _logger.LogDebug( "BroadcastClickedLinks" );
+
+        return new PaginatedResult<BroadcastClickedLink>()
+        {
+            HasMore = false,
+            Data =
+            [
+                new BroadcastClickedLink()
+                {
+                    Id = "b2Zmc2V0OjA",
+                    Url = "https://resend.com/pricing",
+                    Clicks = 42,
+                    UniqueClicks = 30,
+                },
+                new BroadcastClickedLink()
+                {
+                    Id = "b2Zmc2V0OjE",
+                    Url = "https://resend.com/docs",
+                    Clicks = 17,
+                    UniqueClicks = 15,
+                },
+            ],
+        };
+    }
 }

--- a/tools/Resend.Cli/Broadcast/BroadcastClickedLinksCommand.cs
+++ b/tools/Resend.Cli/Broadcast/BroadcastClickedLinksCommand.cs
@@ -1,0 +1,66 @@
+using McMaster.Extensions.CommandLineUtils;
+using Spectre.Console;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+
+namespace Resend.Cli.Broadcast;
+
+/// <summary />
+[Command( "clicked-links", Description = "Lists the clicked links of a broadcast" )]
+public class BroadcastClickedLinksCommand
+{
+    private readonly IResend _resend;
+
+    /// <summary />
+    [Argument( 0, Description = "Broadcast identifier" )]
+    [Required]
+    public Guid? BroadcastId { get; set; }
+
+    /// <summary />
+    [Option( "-j|--json", CommandOptionType.NoValue, Description = "Emit output as JSON array" )]
+    public bool InJson { get; set; }
+
+
+    /// <summary />
+    public BroadcastClickedLinksCommand( IResend resend )
+    {
+        _resend = resend;
+    }
+
+
+    /// <summary />
+    public async Task<int> OnExecuteAsync()
+    {
+        var res = await _resend.BroadcastClickedLinksAsync( this.BroadcastId!.Value );
+        var rows = res.Content.Data;
+
+        if ( this.InJson == true )
+        {
+            var jso = new JsonSerializerOptions() { WriteIndented = true };
+            var json = JsonSerializer.Serialize( rows, jso );
+
+            Console.WriteLine( json );
+        }
+        else
+        {
+            var table = new Table();
+            table.Border = TableBorder.SimpleHeavy;
+            table.AddColumn( "Url" );
+            table.AddColumn( "Clicks" );
+            table.AddColumn( "Unique clicks" );
+
+            foreach ( var c in rows )
+            {
+                table.AddRow(
+                   new Markup( c.Url ),
+                   new Markup( c.Clicks.ToString() ),
+                   new Markup( c.UniqueClicks.ToString() )
+                );
+            }
+
+            AnsiConsole.Write( table );
+        }
+
+        return 0;
+    }
+}

--- a/tools/Resend.Cli/Broadcast/BroadcastClickedLinksCommand.cs
+++ b/tools/Resend.Cli/Broadcast/BroadcastClickedLinksCommand.cs
@@ -17,6 +17,18 @@ public class BroadcastClickedLinksCommand
     public Guid? BroadcastId { get; set; }
 
     /// <summary />
+    [Option( "-l|--limit", CommandOptionType.SingleValue, Description = "Number of links to return" )]
+    public int? Limit { get; set; }
+
+    /// <summary />
+    [Option( "-b|--before", CommandOptionType.SingleValue, Description = "Links before cursor" )]
+    public string? BeforeId { get; set; }
+
+    /// <summary />
+    [Option( "-a|--after", CommandOptionType.SingleValue, Description = "Links after cursor" )]
+    public string? AfterId { get; set; }
+
+    /// <summary />
     [Option( "-j|--json", CommandOptionType.NoValue, Description = "Emit output as JSON array" )]
     public bool InJson { get; set; }
 
@@ -31,7 +43,14 @@ public class BroadcastClickedLinksCommand
     /// <summary />
     public async Task<int> OnExecuteAsync()
     {
-        var res = await _resend.BroadcastClickedLinksAsync( this.BroadcastId!.Value );
+        var q = new PaginatedQuery()
+        {
+            Limit = this.Limit,
+            Before = this.BeforeId,
+            After = this.AfterId,
+        };
+
+        var res = await _resend.BroadcastClickedLinksAsync( this.BroadcastId!.Value, q );
         var rows = res.Content.Data;
 
         if ( this.InJson == true )
@@ -52,7 +71,7 @@ public class BroadcastClickedLinksCommand
             foreach ( var c in rows )
             {
                 table.AddRow(
-                   new Markup( c.Url ),
+                   new Markup( Markup.Escape( c.Url ) ),
                    new Markup( c.Clicks.ToString() ),
                    new Markup( c.UniqueClicks.ToString() )
                 );

--- a/tools/Resend.Cli/BroadcastCommand.cs
+++ b/tools/Resend.Cli/BroadcastCommand.cs
@@ -6,6 +6,7 @@ namespace Resend.Cli;
 [Command( "broadcast", Description = "Broadcast management" )]
 [Subcommand( typeof( Broadcast.BroadcastAddCommand ))]
 [Subcommand( typeof( Broadcast.BroadcastCancelCommand ) )]
+[Subcommand( typeof( Broadcast.BroadcastClickedLinksCommand ) )]
 [Subcommand( typeof( Broadcast.BroadcastDeleteCommand ) )]
 [Subcommand( typeof( Broadcast.BroadcastListCommand ) )]
 [Subcommand( typeof( Broadcast.BroadcastRetrieveCommand ))]


### PR DESCRIPTION
Adds `GET /broadcasts/{id}/clicked-links` — paginated list of a broadcast's clicked links (`url`, `clicks`, `unique_clicks`).

Spec: resend/resend-openapi#95
Reference implementation: resend/resend-node#1077

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `BroadcastClickedLinksAsync()`, `GET /broadcasts/{id}/clicked-links`, and a `broadcast clicked-links` CLI command to fetch a broadcast’s per-link click aggregates with cursor pagination. Previously, clients couldn’t retrieve per-link clicks; now they can read `url`, `clicks`, and `unique_clicks` without affecting delivery or tracking.

- Introduces `BroadcastClickedLink`; its `id` is an opaque cursor for pagination, not a stable identifier.
- Supports `PaginatedQuery` (`limit`, `before`, `after`); returns `PaginatedResult<BroadcastClickedLink>`.
- CLI: `resend broadcast clicked-links <broadcastId> [-l|--limit N] [-b|--before CURSOR] [-a|--after CURSOR] [--json]`; escapes console markup in URLs for safe rendering.
- Adds tests for default and paginated queries; mock API returns sample data for shape validation.
- No changes to existing broadcast endpoints; read-only addition.
- Required: If you implement `IResend`, add `BroadcastClickedLinksAsync()` to your implementation.

<sup>Written for commit bf8440797bf816e89b38fbb27224e916d407d8cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

