### PR TITLE
chore: deprecate the Resend.Cli tool

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,8 +13,10 @@
 | [WebMinimalApi](https://github.com/resend/resend-dotnet/tree/master/examples/WebMinimalApi) | 5001 | Send email from a (minimal) API
 | [WebRazor](https://github.com/resend/resend-dotnet/tree/master/examples/WebRazor)           | 5002 | Send email from a Razor form
 
-The present repository also contains a command-line application will
-implements all of the Resend API: [resend](https://github.com/resend/resend-dotnet/tree/main/tools/Resend.Cli).
+The repository also contains a command-line application:
+[resend](https://github.com/resend/resend-dotnet/tree/main/tools/Resend.Cli).
+It is deprecated and will be removed in a future release. Use the
+official [resend-cli](https://github.com/resend/resend-cli) instead.
 
 
 Async

--- a/tools/Resend.Cli/Program.cs
+++ b/tools/Resend.Cli/Program.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 namespace Resend.Cli;
 
 /// <summary />
-[Command( "resend", Description = "Command-line tool for Resend API" )]
+[Command( "resend", Description = "Command-line tool for Resend API (deprecated: use https://github.com/resend/resend-cli)" )]
 [Subcommand( typeof( ApiKeyCommand ) )]
 [Subcommand( typeof( BroadcastCommand ) )]
 [Subcommand( typeof( ContactCommand ) )]
@@ -26,7 +26,15 @@ public class Program
     public static int Main( string[] args )
     {
         /*
-         * 
+         *
+         */
+        Console.Error.WriteLine( "wrn: This tool is deprecated and will be removed in a future release." );
+        Console.Error.WriteLine( "wrn: Use the official Resend CLI instead: https://github.com/resend/resend-cli" );
+        Console.Error.WriteLine();
+
+
+        /*
+         *
          */
         var app = new CommandLineApplication<Program>();
 


### PR DESCRIPTION
Deprecate the internal `Resend.Cli` tool. The official [resend-cli](https://github.com/resend/resend-cli) replaces it. Removal follows in a later release (#148).

Every run now prints a deprecation warning to stderr and points to the official CLI. Piped stdout stays clean. The `--help` description and `examples/README.md` state the same.

The next tagged release ships the last zips, with the warning baked in.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecates the internal `Resend.Cli` tool in favor of the official `resend-cli`, without breaking existing scripted usage. Previously silent runs now emit a deprecation notice to stderr; stdout remains clean.

- Prints a deprecation warning to stderr on every run and points to https://github.com/resend/resend-cli.
- Updates the command description (`--help`) and `examples/README.md` to mark deprecation.
- Next release will still ship existing binaries with the warning; removal follows in a later release.
- Migration: switch to `resend-cli`.

<sup>Written for commit bc4c2b34d57c25b8c2c7952aeca37a858136660b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

