### PR TITLE
Bump fallback Version to 0.13.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>0.12.0</Version>
+    <Version>0.13.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
**Do not merge before [#140](https://github.com/resend/resend-dotnet/pull/140).** That PR is still open, and merging this first ships a release without it.

Releases:

- [#138](https://github.com/resend/resend-dotnet/pull/138) — `Contact.Properties` is `Dictionary<string, ContactPropertyValue>`, the `{value, type}` shape the API actually returns ([DEV-1624](https://linear.app/resend/issue/DEV-1624/get-contact-properties-response-is-inconsistent-with-docs))
- [#150](https://github.com/resend/resend-dotnet/pull/150) — deprecates the `Resend.Cli` tool
- [#140](https://github.com/resend/resend-dotnet/pull/140), once merged — `ContactEventData.FirstName` / `LastName` are nullable on webhook events ([DEV-1625](https://linear.app/resend/issue/DEV-1625/allow-nullable-contact-first-and-last-names-in-openapi))

Minor rather than patch, following the repo's history and because of the CLI deprecation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets the fallback package version from 0.12.0 to 0.13.0 to publish the next minor release. This matters because local builds and CI without a git tag will now produce 0.13.0 artifacts that include the contact properties fix, nullable contact names in webhook payloads, and the `Resend.Cli` deprecation.

- Merge only after #140 so webhook `FirstName`/`LastName` nullability is included (Linear DEV-1625).
- Included changes:
  - `Contact.Properties` is now `Dictionary<string, ContactPropertyValue>` to match the API (Linear DEV-1624).
  - `FirstName` and `LastName` in contact webhook events are nullable.
  - Deprecates `Resend.Cli`; no immediate migration required, but plan to stop relying on it.

<sup>Written for commit ec74f7f4012cbaa179393623f6011e57907f8ab1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

