### PR TITLE
feat(webhooks): add event listing endpoints

### DIFF
--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -1155,6 +1155,12 @@ public interface IResend
     /// <returns>Response.</returns>
     Task<ResendResponse> WebhookDeleteAsync( Guid webhookId, CancellationToken cancellationToken = default );
 
+    Task<ResendResponse<WebhookEventListResult>> WebhookEventListAsync( Guid webhookId, PaginatedAfterQuery? query = null, CancellationToken cancellationToken = default );
+
+    Task<ResendResponse<WebhookEventDetails>> WebhookEventRetrieveAsync( Guid webhookId, string eventId, CancellationToken cancellationToken = default );
+
+    Task<ResendResponse<WebhookEventAttemptListResult>> WebhookEventAttemptListAsync( Guid webhookId, string eventId, PaginatedAfterQuery? query = null, CancellationToken cancellationToken = default );
+
     #endregion
 
     #region Logs

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -1162,7 +1162,7 @@ public interface IResend
     /// <param name="query">Paginated query.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>List of webhook events.</returns>
-    Task<ResendResponse<WebhookEventListResult>> WebhookEventListAsync( Guid webhookId, PaginatedQuery? query = null, CancellationToken cancellationToken = default );
+    Task<ResendResponse<WebhookEventListResult>> WebhookEventListAsync( Guid webhookId, PaginatedAfterQuery? query = null, CancellationToken cancellationToken = default );
 
     /// <summary>
     /// Retrieves a webhook event.
@@ -1181,7 +1181,7 @@ public interface IResend
     /// <param name="query">Paginated query.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>List of webhook event delivery attempts.</returns>
-    Task<ResendResponse<WebhookEventAttemptListResult>> WebhookEventAttemptListAsync( Guid webhookId, string eventId, PaginatedQuery? query = null, CancellationToken cancellationToken = default );
+    Task<ResendResponse<WebhookEventAttemptListResult>> WebhookEventAttemptListAsync( Guid webhookId, string eventId, PaginatedAfterQuery? query = null, CancellationToken cancellationToken = default );
 
     #endregion
 

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -1155,11 +1155,33 @@ public interface IResend
     /// <returns>Response.</returns>
     Task<ResendResponse> WebhookDeleteAsync( Guid webhookId, CancellationToken cancellationToken = default );
 
-    Task<ResendResponse<WebhookEventListResult>> WebhookEventListAsync( Guid webhookId, PaginatedAfterQuery? query = null, CancellationToken cancellationToken = default );
+    /// <summary>
+    /// Lists webhook events.
+    /// </summary>
+    /// <param name="webhookId">Webhook identifier.</param>
+    /// <param name="query">Paginated query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of webhook events.</returns>
+    Task<ResendResponse<WebhookEventListResult>> WebhookEventListAsync( Guid webhookId, PaginatedQuery? query = null, CancellationToken cancellationToken = default );
 
+    /// <summary>
+    /// Retrieves a webhook event.
+    /// </summary>
+    /// <param name="webhookId">Webhook identifier.</param>
+    /// <param name="eventId">Webhook event identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Webhook event.</returns>
     Task<ResendResponse<WebhookEventDetails>> WebhookEventRetrieveAsync( Guid webhookId, string eventId, CancellationToken cancellationToken = default );
 
-    Task<ResendResponse<WebhookEventAttemptListResult>> WebhookEventAttemptListAsync( Guid webhookId, string eventId, PaginatedAfterQuery? query = null, CancellationToken cancellationToken = default );
+    /// <summary>
+    /// Lists delivery attempts for a webhook event.
+    /// </summary>
+    /// <param name="webhookId">Webhook identifier.</param>
+    /// <param name="eventId">Webhook event identifier.</param>
+    /// <param name="query">Paginated query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of webhook event delivery attempts.</returns>
+    Task<ResendResponse<WebhookEventAttemptListResult>> WebhookEventAttemptListAsync( Guid webhookId, string eventId, PaginatedQuery? query = null, CancellationToken cancellationToken = default );
 
     #endregion
 

--- a/src/Resend/PaginatedAfterQuery.cs
+++ b/src/Resend/PaginatedAfterQuery.cs
@@ -1,8 +1,0 @@
-namespace Resend;
-
-public class PaginatedAfterQuery
-{
-    public int? Limit { get; set; }
-
-    public string? After { get; set; }
-}

--- a/src/Resend/PaginatedAfterQuery.cs
+++ b/src/Resend/PaginatedAfterQuery.cs
@@ -1,0 +1,17 @@
+namespace Resend;
+
+/// <summary>
+/// Pagination query for endpoints that support forward pagination only.
+/// </summary>
+public class PaginatedAfterQuery
+{
+    /// <summary>
+    /// Number of records to return.
+    /// </summary>
+    public int? Limit { get; set; }
+
+    /// <summary>
+    /// Cursor after which records are returned.
+    /// </summary>
+    public string? After { get; set; }
+}

--- a/src/Resend/PaginatedAfterQuery.cs
+++ b/src/Resend/PaginatedAfterQuery.cs
@@ -1,0 +1,8 @@
+namespace Resend;
+
+public class PaginatedAfterQuery
+{
+    public int? Limit { get; set; }
+
+    public string? After { get; set; }
+}

--- a/src/Resend/ResendClient.Webhooks.cs
+++ b/src/Resend/ResendClient.Webhooks.cs
@@ -72,7 +72,8 @@ public partial class ResendClient
     }
 
 
-    public Task<ResendResponse<WebhookEventListResult>> WebhookEventListAsync( Guid webhookId, PaginatedAfterQuery? query = null, CancellationToken cancellationToken = default )
+    /// <inheritdoc />
+    public Task<ResendResponse<WebhookEventListResult>> WebhookEventListAsync( Guid webhookId, PaginatedQuery? query = null, CancellationToken cancellationToken = default )
     {
         var baseUrl = $"/webhooks/{webhookId}/events";
         var url = baseUrl;
@@ -96,6 +97,7 @@ public partial class ResendClient
     }
 
 
+    /// <inheritdoc />
     public Task<ResendResponse<WebhookEventDetails>> WebhookEventRetrieveAsync( Guid webhookId, string eventId, CancellationToken cancellationToken = default )
     {
         var req = new HttpRequestMessage( HttpMethod.Get, $"/webhooks/{webhookId}/events/{Uri.EscapeDataString( eventId )}" );
@@ -104,7 +106,8 @@ public partial class ResendClient
     }
 
 
-    public Task<ResendResponse<WebhookEventAttemptListResult>> WebhookEventAttemptListAsync( Guid webhookId, string eventId, PaginatedAfterQuery? query = null, CancellationToken cancellationToken = default )
+    /// <inheritdoc />
+    public Task<ResendResponse<WebhookEventAttemptListResult>> WebhookEventAttemptListAsync( Guid webhookId, string eventId, PaginatedQuery? query = null, CancellationToken cancellationToken = default )
     {
         var baseUrl = $"/webhooks/{webhookId}/events/{Uri.EscapeDataString( eventId )}/attempts";
         var url = baseUrl;

--- a/src/Resend/ResendClient.Webhooks.cs
+++ b/src/Resend/ResendClient.Webhooks.cs
@@ -73,7 +73,7 @@ public partial class ResendClient
 
 
     /// <inheritdoc />
-    public Task<ResendResponse<WebhookEventListResult>> WebhookEventListAsync( Guid webhookId, PaginatedQuery? query = null, CancellationToken cancellationToken = default )
+    public Task<ResendResponse<WebhookEventListResult>> WebhookEventListAsync( Guid webhookId, PaginatedAfterQuery? query = null, CancellationToken cancellationToken = default )
     {
         var baseUrl = $"/webhooks/{webhookId}/events";
         var url = baseUrl;
@@ -107,7 +107,7 @@ public partial class ResendClient
 
 
     /// <inheritdoc />
-    public Task<ResendResponse<WebhookEventAttemptListResult>> WebhookEventAttemptListAsync( Guid webhookId, string eventId, PaginatedQuery? query = null, CancellationToken cancellationToken = default )
+    public Task<ResendResponse<WebhookEventAttemptListResult>> WebhookEventAttemptListAsync( Guid webhookId, string eventId, PaginatedAfterQuery? query = null, CancellationToken cancellationToken = default )
     {
         var baseUrl = $"/webhooks/{webhookId}/events/{Uri.EscapeDataString( eventId )}/attempts";
         var url = baseUrl;

--- a/src/Resend/ResendClient.Webhooks.cs
+++ b/src/Resend/ResendClient.Webhooks.cs
@@ -70,4 +70,60 @@ public partial class ResendClient
 
         return Execute( req, cancellationToken );
     }
+
+
+    public Task<ResendResponse<WebhookEventListResult>> WebhookEventListAsync( Guid webhookId, PaginatedAfterQuery? query = null, CancellationToken cancellationToken = default )
+    {
+        var baseUrl = $"/webhooks/{webhookId}/events";
+        var url = baseUrl;
+
+        if ( query != null )
+        {
+            var qs = new Dictionary<string, string?>();
+
+            if ( query.Limit.HasValue == true )
+                qs.Add( "limit", query.Limit.Value.ToString() );
+
+            if ( query.After != null )
+                qs.Add( "after", query.After );
+
+            url = QueryHelpers.AddQueryString( baseUrl, qs );
+        }
+
+        var req = new HttpRequestMessage( HttpMethod.Get, url );
+
+        return Execute<WebhookEventListResult, WebhookEventListResult>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    public Task<ResendResponse<WebhookEventDetails>> WebhookEventRetrieveAsync( Guid webhookId, string eventId, CancellationToken cancellationToken = default )
+    {
+        var req = new HttpRequestMessage( HttpMethod.Get, $"/webhooks/{webhookId}/events/{eventId}" );
+
+        return Execute<WebhookEventDetails, WebhookEventDetails>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    public Task<ResendResponse<WebhookEventAttemptListResult>> WebhookEventAttemptListAsync( Guid webhookId, string eventId, PaginatedAfterQuery? query = null, CancellationToken cancellationToken = default )
+    {
+        var baseUrl = $"/webhooks/{webhookId}/events/{eventId}/attempts";
+        var url = baseUrl;
+
+        if ( query != null )
+        {
+            var qs = new Dictionary<string, string?>();
+
+            if ( query.Limit.HasValue == true )
+                qs.Add( "limit", query.Limit.Value.ToString() );
+
+            if ( query.After != null )
+                qs.Add( "after", query.After );
+
+            url = QueryHelpers.AddQueryString( baseUrl, qs );
+        }
+
+        var req = new HttpRequestMessage( HttpMethod.Get, url );
+
+        return Execute<WebhookEventAttemptListResult, WebhookEventAttemptListResult>( req, ( x ) => x, cancellationToken );
+    }
 }

--- a/src/Resend/ResendClient.Webhooks.cs
+++ b/src/Resend/ResendClient.Webhooks.cs
@@ -98,7 +98,7 @@ public partial class ResendClient
 
     public Task<ResendResponse<WebhookEventDetails>> WebhookEventRetrieveAsync( Guid webhookId, string eventId, CancellationToken cancellationToken = default )
     {
-        var req = new HttpRequestMessage( HttpMethod.Get, $"/webhooks/{webhookId}/events/{eventId}" );
+        var req = new HttpRequestMessage( HttpMethod.Get, $"/webhooks/{webhookId}/events/{Uri.EscapeDataString( eventId )}" );
 
         return Execute<WebhookEventDetails, WebhookEventDetails>( req, ( x ) => x, cancellationToken );
     }
@@ -106,7 +106,7 @@ public partial class ResendClient
 
     public Task<ResendResponse<WebhookEventAttemptListResult>> WebhookEventAttemptListAsync( Guid webhookId, string eventId, PaginatedAfterQuery? query = null, CancellationToken cancellationToken = default )
     {
-        var baseUrl = $"/webhooks/{webhookId}/events/{eventId}/attempts";
+        var baseUrl = $"/webhooks/{webhookId}/events/{Uri.EscapeDataString( eventId )}/attempts";
         var url = baseUrl;
 
         if ( query != null )

--- a/src/Resend/WebhookEventAttempt.cs
+++ b/src/Resend/WebhookEventAttempt.cs
@@ -2,17 +2,32 @@ using System.Text.Json.Serialization;
 
 namespace Resend;
 
+/// <summary>
+/// A delivery attempt for a webhook event.
+/// </summary>
 public class WebhookEventAttempt
 {
+    /// <summary>
+    /// Delivery attempt identifier.
+    /// </summary>
     [JsonPropertyName( "id" )]
     public string Id { get; set; } = default!;
 
+    /// <summary>
+    /// HTTP status code returned by the webhook endpoint.
+    /// </summary>
     [JsonPropertyName( "http_status_code" )]
     public int HttpStatusCode { get; set; }
 
+    /// <summary>
+    /// Response returned by the webhook endpoint.
+    /// </summary>
     [JsonPropertyName( "response" )]
     public string Response { get; set; } = default!;
 
+    /// <summary>
+    /// When the delivery attempt was sent.
+    /// </summary>
     [JsonPropertyName( "sent_at" )]
     [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
     public DateTime MomentSent { get; set; }

--- a/src/Resend/WebhookEventAttempt.cs
+++ b/src/Resend/WebhookEventAttempt.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+public class WebhookEventAttempt
+{
+    [JsonPropertyName( "id" )]
+    public string Id { get; set; } = default!;
+
+    [JsonPropertyName( "http_status_code" )]
+    public int HttpStatusCode { get; set; }
+
+    [JsonPropertyName( "response" )]
+    public string Response { get; set; } = default!;
+
+    [JsonPropertyName( "sent_at" )]
+    [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
+    public DateTime MomentSent { get; set; }
+}

--- a/src/Resend/WebhookEventAttemptListResult.cs
+++ b/src/Resend/WebhookEventAttemptListResult.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+public class WebhookEventAttemptListResult
+{
+    [JsonPropertyName( "object" )]
+    public string Object { get; set; } = default!;
+
+    [JsonPropertyName( "has_more" )]
+    public bool HasMore { get; set; }
+
+    [JsonPropertyName( "data" )]
+    public List<WebhookEventAttempt> Data { get; set; } = default!;
+}

--- a/src/Resend/WebhookEventAttemptListResult.cs
+++ b/src/Resend/WebhookEventAttemptListResult.cs
@@ -2,14 +2,26 @@ using System.Text.Json.Serialization;
 
 namespace Resend;
 
+/// <summary>
+/// A page of webhook event delivery attempts.
+/// </summary>
 public class WebhookEventAttemptListResult
 {
+    /// <summary>
+    /// Object type discriminator.
+    /// </summary>
     [JsonPropertyName( "object" )]
     public string Object { get; set; } = default!;
 
+    /// <summary>
+    /// Whether more delivery attempts are available.
+    /// </summary>
     [JsonPropertyName( "has_more" )]
     public bool HasMore { get; set; }
 
+    /// <summary>
+    /// Page of webhook event delivery attempts.
+    /// </summary>
     [JsonPropertyName( "data" )]
     public List<WebhookEventAttempt> Data { get; set; } = default!;
 }

--- a/src/Resend/WebhookEventDetails.cs
+++ b/src/Resend/WebhookEventDetails.cs
@@ -3,28 +3,52 @@ using System.Text.Json.Serialization;
 
 namespace Resend;
 
+/// <summary>
+/// Details about a webhook event and its delivery status.
+/// </summary>
 public class WebhookEventDetails
 {
+    /// <summary>
+    /// Object type discriminator.
+    /// </summary>
     [JsonPropertyName( "object" )]
     public string Object { get; set; } = default!;
 
+    /// <summary>
+    /// Webhook event identifier.
+    /// </summary>
     [JsonPropertyName( "id" )]
     public string Id { get; set; } = default!;
 
+    /// <summary>
+    /// Webhook event type.
+    /// </summary>
     [JsonPropertyName( "type" )]
-    public string Type { get; set; } = default!;
+    public WebhookEventType Type { get; set; }
 
+    /// <summary>
+    /// When the webhook event was created.
+    /// </summary>
     [JsonPropertyName( "created_at" )]
     [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
     public DateTime MomentCreated { get; set; }
 
+    /// <summary>
+    /// Webhook event delivery status.
+    /// </summary>
     [JsonPropertyName( "status" )]
     public WebhookEventLogStatus Status { get; set; }
 
+    /// <summary>
+    /// When the next delivery attempt is scheduled.
+    /// </summary>
     [JsonPropertyName( "next_attempt_at" )]
     [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
     public DateTime? MomentNextAttempt { get; set; }
 
+    /// <summary>
+    /// Webhook event payload.
+    /// </summary>
     [JsonPropertyName( "payload" )]
     public JsonElement Payload { get; set; }
 }

--- a/src/Resend/WebhookEventDetails.cs
+++ b/src/Resend/WebhookEventDetails.cs
@@ -1,0 +1,30 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+public class WebhookEventDetails
+{
+    [JsonPropertyName( "object" )]
+    public string Object { get; set; } = default!;
+
+    [JsonPropertyName( "id" )]
+    public string Id { get; set; } = default!;
+
+    [JsonPropertyName( "type" )]
+    public string Type { get; set; } = default!;
+
+    [JsonPropertyName( "created_at" )]
+    [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
+    public DateTime MomentCreated { get; set; }
+
+    [JsonPropertyName( "status" )]
+    public WebhookEventLogStatus Status { get; set; }
+
+    [JsonPropertyName( "next_attempt_at" )]
+    [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
+    public DateTime? MomentNextAttempt { get; set; }
+
+    [JsonPropertyName( "payload" )]
+    public JsonElement Payload { get; set; }
+}

--- a/src/Resend/WebhookEventListResult.cs
+++ b/src/Resend/WebhookEventListResult.cs
@@ -2,14 +2,26 @@ using System.Text.Json.Serialization;
 
 namespace Resend;
 
+/// <summary>
+/// A page of webhook events.
+/// </summary>
 public class WebhookEventListResult
 {
+    /// <summary>
+    /// Object type discriminator.
+    /// </summary>
     [JsonPropertyName( "object" )]
     public string Object { get; set; } = default!;
 
+    /// <summary>
+    /// Whether more webhook events are available.
+    /// </summary>
     [JsonPropertyName( "has_more" )]
     public bool HasMore { get; set; }
 
+    /// <summary>
+    /// Page of webhook events.
+    /// </summary>
     [JsonPropertyName( "data" )]
     public List<WebhookEventLog> Data { get; set; } = default!;
 }

--- a/src/Resend/WebhookEventListResult.cs
+++ b/src/Resend/WebhookEventListResult.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+public class WebhookEventListResult
+{
+    [JsonPropertyName( "object" )]
+    public string Object { get; set; } = default!;
+
+    [JsonPropertyName( "has_more" )]
+    public bool HasMore { get; set; }
+
+    [JsonPropertyName( "data" )]
+    public List<WebhookEventLog> Data { get; set; } = default!;
+}

--- a/src/Resend/WebhookEventLog.cs
+++ b/src/Resend/WebhookEventLog.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+public class WebhookEventLog
+{
+    [JsonPropertyName( "id" )]
+    public string Id { get; set; } = default!;
+
+    [JsonPropertyName( "type" )]
+    public string Type { get; set; } = default!;
+
+    [JsonPropertyName( "created_at" )]
+    [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
+    public DateTime MomentCreated { get; set; }
+
+    [JsonPropertyName( "status" )]
+    public WebhookEventLogStatus Status { get; set; }
+}

--- a/src/Resend/WebhookEventLog.cs
+++ b/src/Resend/WebhookEventLog.cs
@@ -2,18 +2,33 @@ using System.Text.Json.Serialization;
 
 namespace Resend;
 
+/// <summary>
+/// A webhook event delivery log entry.
+/// </summary>
 public class WebhookEventLog
 {
+    /// <summary>
+    /// Webhook event identifier.
+    /// </summary>
     [JsonPropertyName( "id" )]
     public string Id { get; set; } = default!;
 
+    /// <summary>
+    /// Webhook event type.
+    /// </summary>
     [JsonPropertyName( "type" )]
-    public string Type { get; set; } = default!;
+    public WebhookEventType Type { get; set; }
 
+    /// <summary>
+    /// When the webhook event was created.
+    /// </summary>
     [JsonPropertyName( "created_at" )]
     [JsonConverter( typeof( JsonUtcDateTimeConverter ) )]
     public DateTime MomentCreated { get; set; }
 
+    /// <summary>
+    /// Webhook event delivery status.
+    /// </summary>
     [JsonPropertyName( "status" )]
     public WebhookEventLogStatus Status { get; set; }
 }

--- a/src/Resend/WebhookEventLogStatus.cs
+++ b/src/Resend/WebhookEventLogStatus.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+[JsonConverter( typeof( JsonStringEnumValueConverter<WebhookEventLogStatus> ) )]
+public enum WebhookEventLogStatus
+{
+    [JsonStringValue( "pending" )]
+    Pending = 1,
+
+    [JsonStringValue( "attempting" )]
+    Attempting,
+
+    [JsonStringValue( "success" )]
+    Success,
+
+    [JsonStringValue( "failed" )]
+    Failed,
+}

--- a/src/Resend/WebhookEventLogStatus.cs
+++ b/src/Resend/WebhookEventLogStatus.cs
@@ -2,18 +2,33 @@ using System.Text.Json.Serialization;
 
 namespace Resend;
 
+/// <summary>
+/// Webhook event delivery status.
+/// </summary>
 [JsonConverter( typeof( JsonStringEnumValueConverter<WebhookEventLogStatus> ) )]
 public enum WebhookEventLogStatus
 {
+    /// <summary>
+    /// The webhook event is waiting to be delivered.
+    /// </summary>
     [JsonStringValue( "pending" )]
     Pending = 1,
 
+    /// <summary>
+    /// Delivery of the webhook event is in progress.
+    /// </summary>
     [JsonStringValue( "attempting" )]
     Attempting,
 
+    /// <summary>
+    /// The webhook event was delivered successfully.
+    /// </summary>
     [JsonStringValue( "success" )]
     Success,
 
+    /// <summary>
+    /// Delivery of the webhook event failed.
+    /// </summary>
     [JsonStringValue( "failed" )]
     Failed,
 }

--- a/tests/Resend.Tests/ResendClientTests.Webhook.cs
+++ b/tests/Resend.Tests/ResendClientTests.Webhook.cs
@@ -73,7 +73,7 @@ public partial class ResendClientTests
     [Fact]
     public async Task WebhookEventList()
     {
-        var resp = await _resend.WebhookEventListAsync( Guid.NewGuid(), new PaginatedAfterQuery()
+        var resp = await _resend.WebhookEventListAsync( Guid.NewGuid(), new PaginatedQuery()
         {
             Limit = 1,
             After = "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2",
@@ -84,6 +84,7 @@ public partial class ResendClientTests
         Assert.True( resp.Content.HasMore );
         Assert.Single( resp.Content.Data );
         Assert.Equal( "msg_2aQqFEiKYaC8Q35b3e97qyRmaN7", resp.Content.Data[ 0 ].Id );
+        Assert.Equal( WebhookEventType.EmailSent, resp.Content.Data[ 0 ].Type );
         Assert.Equal( WebhookEventLogStatus.Success, resp.Content.Data[ 0 ].Status );
     }
 
@@ -97,6 +98,7 @@ public partial class ResendClientTests
         Assert.NotNull( resp.Content );
         Assert.Equal( "webhook_event", resp.Content.Object );
         Assert.Equal( eventId, resp.Content.Id );
+        Assert.Equal( WebhookEventType.EmailSent, resp.Content.Type );
         Assert.Equal( WebhookEventLogStatus.Failed, resp.Content.Status );
         Assert.Null( resp.Content.MomentNextAttempt );
         Assert.Equal( "email.sent", resp.Content.Payload.GetProperty( "type" ).GetString() );
@@ -109,7 +111,7 @@ public partial class ResendClientTests
         var resp = await _resend.WebhookEventAttemptListAsync(
             Guid.NewGuid(),
             "msg_2aQqFEiKYaC8Q35b3e97qyRmaN7?attempt=1",
-            new PaginatedAfterQuery()
+            new PaginatedQuery()
             {
                 Limit = 1,
                 After = "atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd",

--- a/tests/Resend.Tests/ResendClientTests.Webhook.cs
+++ b/tests/Resend.Tests/ResendClientTests.Webhook.cs
@@ -1,4 +1,7 @@
-﻿namespace Resend.Tests;
+using System.Net;
+using System.Text;
+
+namespace Resend.Tests;
 
 /// <summary />
 public partial class ResendClientTests
@@ -73,7 +76,7 @@ public partial class ResendClientTests
     [Fact]
     public async Task WebhookEventList()
     {
-        var resp = await _resend.WebhookEventListAsync( Guid.NewGuid(), new PaginatedQuery()
+        var resp = await _resend.WebhookEventListAsync( Guid.NewGuid(), new PaginatedAfterQuery()
         {
             Limit = 1,
             After = "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2",
@@ -86,6 +89,24 @@ public partial class ResendClientTests
         Assert.Equal( "msg_2aQqFEiKYaC8Q35b3e97qyRmaN7", resp.Content.Data[ 0 ].Id );
         Assert.Equal( WebhookEventType.EmailSent, resp.Content.Data[ 0 ].Type );
         Assert.Equal( WebhookEventLogStatus.Success, resp.Content.Data[ 0 ].Status );
+    }
+
+
+    [Fact]
+    public async Task WebhookEventList_SendsSupportedPaginationQuery()
+    {
+        var handler = new WebhookRecordingHandler();
+        var resend = ResendClient.Create( new ResendClientOptions() { ApiToken = "re_test_123" }, new HttpClient( handler ) );
+        var webhookId = Guid.NewGuid();
+
+        await resend.WebhookEventListAsync( webhookId, new PaginatedAfterQuery()
+        {
+            Limit = 1,
+            After = "msg_cursor",
+        } );
+
+        var req = Assert.Single( handler.Requests );
+        Assert.Equal( $"/webhooks/{webhookId}/events?limit=1&after=msg_cursor", req.RequestUri!.PathAndQuery );
     }
 
 
@@ -111,7 +132,7 @@ public partial class ResendClientTests
         var resp = await _resend.WebhookEventAttemptListAsync(
             Guid.NewGuid(),
             "msg_2aQqFEiKYaC8Q35b3e97qyRmaN7?attempt=1",
-            new PaginatedQuery()
+            new PaginatedAfterQuery()
             {
                 Limit = 1,
                 After = "atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd",
@@ -124,5 +145,40 @@ public partial class ResendClientTests
         Assert.Single( resp.Content.Data );
         Assert.Equal( "atmpt_3ZbUCwvGmIT4mLIN6d3Yz0Ainbe", resp.Content.Data[ 0 ].Id );
         Assert.Equal( 200, resp.Content.Data[ 0 ].HttpStatusCode );
+    }
+
+
+    [Fact]
+    public async Task WebhookEventAttemptList_SendsSupportedPaginationQuery()
+    {
+        var handler = new WebhookRecordingHandler();
+        var resend = ResendClient.Create( new ResendClientOptions() { ApiToken = "re_test_123" }, new HttpClient( handler ) );
+        var webhookId = Guid.NewGuid();
+
+        await resend.WebhookEventAttemptListAsync( webhookId, "msg_event", new PaginatedAfterQuery()
+        {
+            Limit = 1,
+            After = "atmpt_cursor",
+        } );
+
+        var req = Assert.Single( handler.Requests );
+        Assert.Equal( $"/webhooks/{webhookId}/events/msg_event/attempts?limit=1&after=atmpt_cursor", req.RequestUri!.PathAndQuery );
+    }
+
+
+    private class WebhookRecordingHandler : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+
+        protected override Task<HttpResponseMessage> SendAsync( HttpRequestMessage request, CancellationToken cancellationToken )
+        {
+            Requests.Add( request );
+
+            var resp = new HttpResponseMessage( HttpStatusCode.OK );
+            resp.Content = new StringContent( """{"object":"list","has_more":false,"data":[]}""", Encoding.UTF8, "application/json" );
+
+            return Task.FromResult( resp );
+        }
     }
 }

--- a/tests/Resend.Tests/ResendClientTests.Webhook.cs
+++ b/tests/Resend.Tests/ResendClientTests.Webhook.cs
@@ -91,10 +91,12 @@ public partial class ResendClientTests
     [Fact]
     public async Task WebhookEventRetrieve()
     {
-        var resp = await _resend.WebhookEventRetrieveAsync( Guid.NewGuid(), "msg_2aQqFEiKYaC8Q35b3e97qyRmaN7" );
+        var eventId = "msg_2aQqFEiKYaC8Q35b3e97qyRmaN7?attempt=1";
+        var resp = await _resend.WebhookEventRetrieveAsync( Guid.NewGuid(), eventId );
 
         Assert.NotNull( resp.Content );
         Assert.Equal( "webhook_event", resp.Content.Object );
+        Assert.Equal( eventId, resp.Content.Id );
         Assert.Equal( WebhookEventLogStatus.Failed, resp.Content.Status );
         Assert.Null( resp.Content.MomentNextAttempt );
         Assert.Equal( "email.sent", resp.Content.Payload.GetProperty( "type" ).GetString() );
@@ -106,7 +108,7 @@ public partial class ResendClientTests
     {
         var resp = await _resend.WebhookEventAttemptListAsync(
             Guid.NewGuid(),
-            "msg_2aQqFEiKYaC8Q35b3e97qyRmaN7",
+            "msg_2aQqFEiKYaC8Q35b3e97qyRmaN7?attempt=1",
             new PaginatedAfterQuery()
             {
                 Limit = 1,

--- a/tests/Resend.Tests/ResendClientTests.Webhook.cs
+++ b/tests/Resend.Tests/ResendClientTests.Webhook.cs
@@ -68,4 +68,57 @@ public partial class ResendClientTests
 
         Assert.NotNull( resp );
     }
+
+
+    [Fact]
+    public async Task WebhookEventList()
+    {
+        var resp = await _resend.WebhookEventListAsync( Guid.NewGuid(), new PaginatedAfterQuery()
+        {
+            Limit = 1,
+            After = "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+        } );
+
+        Assert.NotNull( resp.Content );
+        Assert.Equal( "list", resp.Content.Object );
+        Assert.True( resp.Content.HasMore );
+        Assert.Single( resp.Content.Data );
+        Assert.Equal( "msg_2aQqFEiKYaC8Q35b3e97qyRmaN7", resp.Content.Data[ 0 ].Id );
+        Assert.Equal( WebhookEventLogStatus.Success, resp.Content.Data[ 0 ].Status );
+    }
+
+
+    [Fact]
+    public async Task WebhookEventRetrieve()
+    {
+        var resp = await _resend.WebhookEventRetrieveAsync( Guid.NewGuid(), "msg_2aQqFEiKYaC8Q35b3e97qyRmaN7" );
+
+        Assert.NotNull( resp.Content );
+        Assert.Equal( "webhook_event", resp.Content.Object );
+        Assert.Equal( WebhookEventLogStatus.Failed, resp.Content.Status );
+        Assert.Null( resp.Content.MomentNextAttempt );
+        Assert.Equal( "email.sent", resp.Content.Payload.GetProperty( "type" ).GetString() );
+    }
+
+
+    [Fact]
+    public async Task WebhookEventAttemptList()
+    {
+        var resp = await _resend.WebhookEventAttemptListAsync(
+            Guid.NewGuid(),
+            "msg_2aQqFEiKYaC8Q35b3e97qyRmaN7",
+            new PaginatedAfterQuery()
+            {
+                Limit = 1,
+                After = "atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd",
+            }
+        );
+
+        Assert.NotNull( resp.Content );
+        Assert.Equal( "list", resp.Content.Object );
+        Assert.True( resp.Content.HasMore );
+        Assert.Single( resp.Content.Data );
+        Assert.Equal( "atmpt_3ZbUCwvGmIT4mLIN6d3Yz0Ainbe", resp.Content.Data[ 0 ].Id );
+        Assert.Equal( 200, resp.Content.Data[ 0 ].HttpStatusCode );
+    }
 }

--- a/tools/Resend.ApiServer/Controllers/WebhookController.cs
+++ b/tools/Resend.ApiServer/Controllers/WebhookController.cs
@@ -123,6 +123,7 @@ public class WebhookController : ControllerBase
     }
 
 
+    /// <summary />
     [HttpGet]
     [Route( "webhooks/{webhookId}/events" )]
     public WebhookEventListResult WebhookEventList(
@@ -141,7 +142,7 @@ public class WebhookController : ControllerBase
                 new WebhookEventLog()
                 {
                     Id = "msg_2aQqFEiKYaC8Q35b3e97qyRmaN7",
-                    Type = "email.sent",
+                    Type = WebhookEventType.EmailSent,
                     MomentCreated = DateTime.UtcNow,
                     Status = WebhookEventLogStatus.Success,
                 },
@@ -150,6 +151,7 @@ public class WebhookController : ControllerBase
     }
 
 
+    /// <summary />
     [HttpGet]
     [Route( "webhooks/{webhookId}/events/{eventId}" )]
     public WebhookEventDetails WebhookEventRetrieve( [FromRoute] Guid webhookId, [FromRoute] string eventId )
@@ -160,7 +162,7 @@ public class WebhookController : ControllerBase
         {
             Object = "webhook_event",
             Id = eventId,
-            Type = "email.sent",
+            Type = WebhookEventType.EmailSent,
             MomentCreated = DateTime.UtcNow,
             Status = WebhookEventLogStatus.Failed,
             MomentNextAttempt = null,
@@ -173,6 +175,7 @@ public class WebhookController : ControllerBase
     }
 
 
+    /// <summary />
     [HttpGet]
     [Route( "webhooks/{webhookId}/events/{eventId}/attempts" )]
     public WebhookEventAttemptListResult WebhookEventAttemptList(

--- a/tools/Resend.ApiServer/Controllers/WebhookController.cs
+++ b/tools/Resend.ApiServer/Controllers/WebhookController.cs
@@ -121,4 +121,82 @@ public class WebhookController : ControllerBase
             ],
         };
     }
+
+
+    [HttpGet]
+    [Route( "webhooks/{webhookId}/events" )]
+    public WebhookEventListResult WebhookEventList(
+        [FromRoute] Guid webhookId,
+        [FromQuery] string? limit = null,
+        [FromQuery] string? after = null
+    )
+    {
+        _logger.LogDebug( "WebhookEventList" );
+
+        return new WebhookEventListResult()
+        {
+            Object = "list",
+            HasMore = limit == "1" && after == "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+            Data = [
+                new WebhookEventLog()
+                {
+                    Id = "msg_2aQqFEiKYaC8Q35b3e97qyRmaN7",
+                    Type = "email.sent",
+                    MomentCreated = DateTime.UtcNow,
+                    Status = WebhookEventLogStatus.Success,
+                },
+            ],
+        };
+    }
+
+
+    [HttpGet]
+    [Route( "webhooks/{webhookId}/events/{eventId}" )]
+    public WebhookEventDetails WebhookEventRetrieve( [FromRoute] Guid webhookId, [FromRoute] string eventId )
+    {
+        _logger.LogDebug( "WebhookEventRetrieve" );
+
+        return new WebhookEventDetails()
+        {
+            Object = "webhook_event",
+            Id = eventId,
+            Type = "email.sent",
+            MomentCreated = DateTime.UtcNow,
+            Status = WebhookEventLogStatus.Failed,
+            MomentNextAttempt = null,
+            Payload = System.Text.Json.JsonSerializer.SerializeToElement( new
+            {
+                type = "email.sent",
+                data = new { email_id = "email_123" },
+            } ),
+        };
+    }
+
+
+    [HttpGet]
+    [Route( "webhooks/{webhookId}/events/{eventId}/attempts" )]
+    public WebhookEventAttemptListResult WebhookEventAttemptList(
+        [FromRoute] Guid webhookId,
+        [FromRoute] string eventId,
+        [FromQuery] string? limit = null,
+        [FromQuery] string? after = null
+    )
+    {
+        _logger.LogDebug( "WebhookEventAttemptList" );
+
+        return new WebhookEventAttemptListResult()
+        {
+            Object = "list",
+            HasMore = limit == "1" && after == "atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd",
+            Data = [
+                new WebhookEventAttempt()
+                {
+                    Id = "atmpt_3ZbUCwvGmIT4mLIN6d3Yz0Ainbe",
+                    HttpStatusCode = 200,
+                    Response = "{\"ok\":true}",
+                    MomentSent = DateTime.UtcNow,
+                },
+            ],
+        };
+    }
 }


### PR DESCRIPTION
Adds manually implemented webhook event listing, retrieval, and delivery-attempt listing methods with endpoint-specific pagination and exact response models, following resend-openapi#106.

Linear: https://linear.app/resend/issue/DEV-1930

Tests: .NET 8 build, 228 tests, and live API calls.