### PR TITLE
feat(segments): add SegmentUpdateAsync for PATCH /segments/:id

### DIFF
--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -956,6 +956,15 @@ public interface IResend
     Task<ResendResponse<Segment>> SegmentRetrieveAsync( Guid segmentId, CancellationToken cancellationToken = default );
 
     /// <summary>
+    /// Updates a segment.
+    /// </summary>
+    /// <param name="segmentId">Segment identifier.</param>
+    /// <param name="segment">Segment data.</param>
+    /// <param name="cancellationToken">Cancelation token.</param>
+    /// <returns>Updated segment.</returns>
+    Task<ResendResponse<SegmentUpdateResult>> SegmentUpdateAsync( Guid segmentId, SegmentData segment, CancellationToken cancellationToken = default );
+
+    /// <summary>
     /// Deletes a segment.
     /// </summary>
     /// <param name="segmentId">Segment identifier.</param>

--- a/src/Resend/README.md
+++ b/src/Resend/README.md
@@ -20,7 +20,7 @@ The `ResendClient` supports the following objects (and methods):
 * Broadcast (List, Add, Retrieve, Update, Send, Schedule, Delete)
 * Audience (List, Add, Retrieve, Delete)
 * Contact (List, Add, Retrieve, Update, Delete)
-* Segment (List, Create, Retrieve, Delete)
+* Segment (List, Create, Retrieve, Update, Delete)
 * Topics (List, Create, Retrieve, Update, Delete)
 * Templates (List, Create, Retrieve, Update, Delete, Publish, Duplicate)
 * Webhooks (List, Create, Retrieve, Update, Delete)

--- a/src/Resend/ResendClient.Segments.cs
+++ b/src/Resend/ResendClient.Segments.cs
@@ -55,6 +55,17 @@ public partial class ResendClient
 
 
     /// <inheritdoc />
+    public Task<ResendResponse<SegmentUpdateResult>> SegmentUpdateAsync( Guid segmentId, SegmentData segment, CancellationToken cancellationToken = default )
+    {
+        var path = $"/segments/{segmentId}";
+        var req = new HttpRequestMessage( HttpMethod.Patch, path );
+        req.Content = JsonContent.Create( segment );
+
+        return Execute<SegmentUpdateResult, SegmentUpdateResult>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
     public Task<ResendResponse> SegmentDeleteAsync( Guid segmentId, CancellationToken cancellationToken = default )
     {
         var req = new HttpRequestMessage( HttpMethod.Delete, $"/segments/{segmentId}" );

--- a/src/Resend/SegmentUpdateResult.cs
+++ b/src/Resend/SegmentUpdateResult.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Resend;
+
+/// <summary>
+/// Result of updating a segment.
+/// </summary>
+public class SegmentUpdateResult
+{
+    /// <summary>
+    /// Object type discriminator.
+    /// </summary>
+    [JsonPropertyName( "object" )]
+    public string Object { get; set; } = default!;
+
+    /// <summary>
+    /// Segment identifier.
+    /// </summary>
+    [JsonPropertyName( "id" )]
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Segment name.
+    /// </summary>
+    [JsonPropertyName( "name" )]
+    public string Name { get; set; } = default!;
+}

--- a/src/Resend/SegmentUpdateResult.cs
+++ b/src/Resend/SegmentUpdateResult.cs
@@ -18,10 +18,4 @@ public class SegmentUpdateResult
     /// </summary>
     [JsonPropertyName( "id" )]
     public Guid Id { get; set; }
-
-    /// <summary>
-    /// Segment name.
-    /// </summary>
-    [JsonPropertyName( "name" )]
-    public string Name { get; set; } = default!;
 }

--- a/tests/Resend.Tests/ResendClientTests.Segment.cs
+++ b/tests/Resend.Tests/ResendClientTests.Segment.cs
@@ -17,6 +17,5 @@ public partial class ResendClientTests
         Assert.NotNull( resp );
         Assert.NotNull( resp.Content );
         Assert.Equal( segmentId, resp.Content.Id );
-        Assert.Equal( "Renamed segment", resp.Content.Name );
     }
 }

--- a/tests/Resend.Tests/ResendClientTests.Segment.cs
+++ b/tests/Resend.Tests/ResendClientTests.Segment.cs
@@ -1,0 +1,22 @@
+namespace Resend.Tests;
+
+/// <summary />
+public partial class ResendClientTests
+{
+    /// <summary/>
+    [Fact]
+    public async Task SegmentUpdate()
+    {
+        var segmentId = Guid.NewGuid();
+
+        var resp = await _resend.SegmentUpdateAsync( segmentId, new SegmentData()
+        {
+            Name = "Renamed segment",
+        } );
+
+        Assert.NotNull( resp );
+        Assert.NotNull( resp.Content );
+        Assert.Equal( segmentId, resp.Content.Id );
+        Assert.Equal( "Renamed segment", resp.Content.Name );
+    }
+}

--- a/tools/Resend.ApiServer/Controllers/SegmentController.cs
+++ b/tools/Resend.ApiServer/Controllers/SegmentController.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Resend.ApiServer.Controllers;
+
+/// <summary />
+[ApiController]
+public class SegmentController : ControllerBase
+{
+    private readonly ILogger<SegmentController> _logger;
+
+
+    /// <summary />
+    public SegmentController( ILogger<SegmentController> logger )
+    {
+        _logger = logger;
+    }
+
+
+    /// <summary />
+    [HttpPatch]
+    [Route( "segments/{id}" )]
+    public SegmentUpdateResult SegmentUpdate( [FromRoute] Guid id, [FromBody] SegmentData data )
+    {
+        _logger.LogDebug( "SegmentUpdate" );
+
+        return new SegmentUpdateResult()
+        {
+            Object = "segment",
+            Id = id,
+            Name = data.Name,
+        };
+    }
+}

--- a/tools/Resend.ApiServer/Controllers/SegmentController.cs
+++ b/tools/Resend.ApiServer/Controllers/SegmentController.cs
@@ -27,7 +27,6 @@ public class SegmentController : ControllerBase
         {
             Object = "segment",
             Id = id,
-            Name = data.Name,
         };
     }
 }

--- a/tools/Resend.Cli/Segment/SegmentUpdateCommand.cs
+++ b/tools/Resend.Cli/Segment/SegmentUpdateCommand.cs
@@ -1,0 +1,42 @@
+using McMaster.Extensions.CommandLineUtils;
+using System.ComponentModel.DataAnnotations;
+
+namespace Resend.Cli.Segment;
+
+/// <summary />
+[Command( "update", Description = "Update a segment" )]
+public class SegmentUpdateCommand
+{
+    private readonly IResend _resend;
+
+    /// <summary />
+    [Argument( 0, Description = "Segment identifier" )]
+    [Required]
+    public Guid? SegmentId { get; set; }
+
+    /// <summary />
+    [Argument( 1, Description = "Segment name" )]
+    [Required]
+    public string? Name { get; set; }
+
+
+    /// <summary />
+    public SegmentUpdateCommand( IResend resend )
+    {
+        _resend = resend;
+    }
+
+
+    /// <summary />
+    public async Task<int> OnExecuteAsync()
+    {
+        var data = new SegmentData()
+        {
+            Name = this.Name!,
+        };
+
+        await _resend.SegmentUpdateAsync( this.SegmentId!.Value, data );
+
+        return 0;
+    }
+}

--- a/tools/Resend.Cli/SegmentCommand.cs
+++ b/tools/Resend.Cli/SegmentCommand.cs
@@ -8,6 +8,7 @@ namespace Resend.Cli;
 [Subcommand( typeof( Segment.SegmentDeleteCommand ) )]
 [Subcommand( typeof( Segment.SegmentListCommand ) )]
 [Subcommand( typeof( Segment.SegmentRetrieveCommand ) )]
+[Subcommand( typeof( Segment.SegmentUpdateCommand ) )]
 public class SegmentCommand
 {
     /// <summary />


### PR DESCRIPTION
Adds `SegmentUpdateAsync` for `PATCH /segments/:id`, which renames a segment.

```csharp
var resp = await resend.SegmentUpdateAsync( segmentId, new SegmentData()
{
    Name = "New segment name",
} );

Console.WriteLine( resp.Content.Name );
```

**Params**

- `name` (string, required) — the new segment name.

**Response**

```json
{
  "object": "segment",
  "id": "...",
}
```