### PR TITLE
Bump fallback Version to 0.14.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>0.13.0</Version>
+    <Version>0.14.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Bumps `Directory.Build.props` `Version` to 0.14.0. Minor release covering #153 (`SegmentUpdateAsync`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the fallback `Version` in `Directory.Build.props` from 0.13.0 to 0.14.0 for the minor release covering `SegmentUpdateAsync` (#153).

<sup>Written for commit 4ff4ab5e019dc2497547bb91013b357e833741b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

