### PR TITLE
Bump fallback Version to 0.15.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>0.14.0</Version>
+    <Version>0.15.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Bump the fallback version to 0.15.0. Minor release covering #152 (webhook event listing endpoints).

Linear: https://linear.app/resend/issue/DEV-1930

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the fallback version from 0.14.0 to 0.15.0 to include the webhook event listing endpoints from #152. Completes the minor release for DEV-1930.

<sup>Written for commit 010ad7496a95efcec28a3fa975b5d1363ee2b60b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

