### PR TITLE
docs(webhooks): document event listing support

### DIFF
--- a/src/Resend/README.md
+++ b/src/Resend/README.md
@@ -23,7 +23,7 @@ The `ResendClient` supports the following objects (and methods):
 * Segment (List, Create, Retrieve, Update, Delete)
 * Topics (List, Create, Retrieve, Update, Delete)
 * Templates (List, Create, Retrieve, Update, Delete, Publish, Duplicate)
-* Webhooks (List, Create, Retrieve, Update, Delete)
+* Webhooks (List, Create, Retrieve, Update, Delete, Event List, Event Retrieve, Event Attempt List)
 
 
 Installing via NuGet


### PR DESCRIPTION
## Summary

- document webhook event listing support
- document event retrieval and delivery-attempt listing support

## Testing

- `./cicd/ci.sh`

Linear: https://linear.app/resend/issue/DEV-1930

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents webhook event listing support by adding Event List, Event Retrieve, and Event Attempt List to the README's Webhooks methods list.

<sup>Written for commit 67b3b33d5fa55285fe00c3d7c32af34ec3c12885. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

