### PR TITLE
chore: bump fallback version to 0.16.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>0.15.0</Version>
+    <Version>0.16.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps the fallback version from `0.15.0` to `0.16.0` in `Directory.Build.props` so projects without an explicit version use the latest release.

<sup>Written for commit 9cf3f7a5948d03a3e37e39fb1f20435e886a1858. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

