### PR TITLE
feat(webhooks): add signing secret rotation endpoint

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>0.16.0</Version>
+    <Version>0.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -1165,6 +1165,14 @@ public interface IResend
     Task<ResendResponse> WebhookDeleteAsync( Guid webhookId, CancellationToken cancellationToken = default );
 
     /// <summary>
+    /// Rotates the signing secret of a webhook.
+    /// </summary>
+    /// <param name="webhookId">Webhook identifier.</param>
+    /// <param name="cancellationToken">Cancelation token.</param>
+    /// <returns>Webhook identifier and new signing secret.</returns>
+    Task<ResendResponse<WebhookNew>> WebhookRotateSigningSecretAsync( Guid webhookId, CancellationToken cancellationToken = default );
+
+    /// <summary>
     /// Lists webhook events.
     /// </summary>
     /// <param name="webhookId">Webhook identifier.</param>

--- a/src/Resend/README.md
+++ b/src/Resend/README.md
@@ -23,7 +23,7 @@ The `ResendClient` supports the following objects (and methods):
 * Segment (List, Create, Retrieve, Update, Delete)
 * Topics (List, Create, Retrieve, Update, Delete)
 * Templates (List, Create, Retrieve, Update, Delete, Publish, Duplicate)
-* Webhooks (List, Create, Retrieve, Update, Delete, Event List, Event Retrieve, Event Replay, Event Attempt List)
+* Webhooks (List, Create, Retrieve, Update, Delete, Rotate Signing Secret, Event List, Event Retrieve, Event Replay, Event Attempt List)
 
 
 Installing via NuGet

--- a/src/Resend/ResendClient.Webhooks.cs
+++ b/src/Resend/ResendClient.Webhooks.cs
@@ -73,6 +73,15 @@ public partial class ResendClient
 
 
     /// <inheritdoc />
+    public Task<ResendResponse<WebhookNew>> WebhookRotateSigningSecretAsync( Guid webhookId, CancellationToken cancellationToken = default )
+    {
+        var req = new HttpRequestMessage( HttpMethod.Post, $"/webhooks/{webhookId}/signing-secret/rotate" );
+
+        return Execute<WebhookNew, WebhookNew>( req, ( x ) => x, cancellationToken );
+    }
+
+
+    /// <inheritdoc />
     public Task<ResendResponse<WebhookEventListResult>> WebhookEventListAsync( Guid webhookId, PaginatedAfterQuery? query = null, CancellationToken cancellationToken = default )
     {
         var baseUrl = $"/webhooks/{webhookId}/events";

--- a/src/Resend/WebhookNew.cs
+++ b/src/Resend/WebhookNew.cs
@@ -3,7 +3,7 @@
 namespace Resend;
 
 /// <summary>
-/// Response when the webhook is created.
+/// Response when the webhook is created or its signing secret is rotated.
 /// </summary>
 public class WebhookNew
 {

--- a/tests/Resend.Tests/ResendClientTests.Webhook.cs
+++ b/tests/Resend.Tests/ResendClientTests.Webhook.cs
@@ -73,6 +73,19 @@ public partial class ResendClientTests
     }
 
 
+    /// <summary/>
+    [Fact]
+    public async Task WebhookRotateSigningSecret()
+    {
+        var webhookId = Guid.NewGuid();
+        var resp = await _resend.WebhookRotateSigningSecretAsync( webhookId );
+
+        Assert.NotNull( resp );
+        Assert.Equal( webhookId, resp.Content.Id );
+        Assert.Equal( "whsec_rotated-secret", resp.Content.SigningSecret );
+    }
+
+
     [Fact]
     public async Task WebhookEventList()
     {

--- a/tools/Resend.ApiServer/Controllers/WebhookController.cs
+++ b/tools/Resend.ApiServer/Controllers/WebhookController.cs
@@ -78,6 +78,21 @@ public class WebhookController : ControllerBase
 
 
     /// <summary />
+    [HttpPost]
+    [Route( "webhooks/{id}/signing-secret/rotate" )]
+    public WebhookNew WebhookRotateSigningSecret( [FromRoute] Guid id )
+    {
+        _logger.LogDebug( "WebhookRotateSigningSecret" );
+
+        return new WebhookNew()
+        {
+            Id = id,
+            SigningSecret = "whsec_rotated-secret",
+        };
+    }
+
+
+    /// <summary />
     [HttpGet]
     [Route( "webhooks" )]
     public PaginatedResult<Webhook> WebhookList(


### PR DESCRIPTION
Adds `WebhookRotateSigningSecretAsync(webhookId)` for `POST /webhooks/{webhook_id}/signing-secret/rotate`, spec in https://github.com/resend/resend-openapi/pull/113. The response is the same `{object, id, signing_secret}` shape create webhook returns, so it reuses `WebhookNew` instead of adding a type; the mock server and the test follow the same layout as the event replay endpoint (#157). Rollout sub-issue: https://linear.app/resend/issue/DEV-2075

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `WebhookRotateSigningSecretAsync(webhookId)` to rotate a webhook's signing secret via `POST /webhooks/{webhook_id}/signing-secret/rotate`, resolving DEV-2075.

- Reuses the existing `WebhookNew` response type since the endpoint returns the same shape as webhook creation.
- Updates the mock server and adds a unit test.
- Bumps the package version to 0.17.0 and documents the new operation in the README.

<sup>Written for commit 94227d4ca1fc8fdb60a911d4632fc01609b0b6fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

