### PR TITLE
feat(broadcasts): add duplicate endpoint

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>0.17.0</Version>
+    <Version>0.18.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Resend/IResend.cs
+++ b/src/Resend/IResend.cs
@@ -855,6 +855,15 @@ public interface IResend
     Task<ResendResponse> BroadcastCancelAsync( Guid broadcastId, CancellationToken cancellationToken = default );
 
     /// <summary>
+    /// Duplicates a broadcast.
+    /// </summary>
+    /// <param name="broadcastId">Broadcast identifier.</param>
+    /// <param name="cancellationToken">Cancelation token.</param>
+    /// <returns>Identifier of newly created duplicate.</returns>
+    /// <see href="https://resend.com/docs/api-reference/broadcasts/duplicate-broadcast"/>
+    Task<ResendResponse<Guid>> BroadcastDuplicateAsync( Guid broadcastId, CancellationToken cancellationToken = default );
+
+    /// <summary>
     /// Lists all broadcasts.
     /// </summary>
     /// <param name="cancellationToken">Cancelation token.</param>

--- a/src/Resend/README.md
+++ b/src/Resend/README.md
@@ -17,7 +17,7 @@ The `ResendClient` supports the following objects (and methods):
 * Receiving (List, Retrieve, Attachment List, Attachment Retrieve)
 * Domain (List, Add, Retrieve, Update, Verify, Delete)
 * API key (List, Create, Delete)
-* Broadcast (List, Add, Retrieve, Update, Send, Schedule, Delete)
+* Broadcast (List, Add, Retrieve, Update, Send, Schedule, Duplicate, Delete)
 * Audience (List, Add, Retrieve, Delete)
 * Contact (List, Add, Retrieve, Update, Delete)
 * Segment (List, Create, Retrieve, Update, Delete)

--- a/src/Resend/ResendClient.cs
+++ b/src/Resend/ResendClient.cs
@@ -522,6 +522,16 @@ public partial class ResendClient : IResend
 
 
     /// <inheritdoc/>
+    public Task<ResendResponse<Guid>> BroadcastDuplicateAsync( Guid broadcastId, CancellationToken cancellationToken = default )
+    {
+        var path = $"/broadcasts/{broadcastId}/duplicate";
+        var req = new HttpRequestMessage( HttpMethod.Post, path );
+
+        return Execute<ObjectId, Guid>( req, ( x ) => x.Id, cancellationToken );
+    }
+
+
+    /// <inheritdoc/>
     public Task<ResendResponse<List<Broadcast>>> BroadcastListAsync( CancellationToken cancellationToken = default )
     {
         var path = $"/broadcasts";

--- a/tests/Resend.Tests/ResendClientTests.cs
+++ b/tests/Resend.Tests/ResendClientTests.cs
@@ -487,6 +487,21 @@ public partial class ResendClientTests : IClassFixture<WebApplicationFactory<Pro
 
     /// <summary/>
     [Fact]
+    public async Task BroadcastDuplicate()
+    {
+        var broadcastId = Guid.NewGuid();
+
+        var resp = await _resend.BroadcastDuplicateAsync( broadcastId );
+
+        Assert.NotNull( resp );
+        Assert.True( resp.Success );
+        Assert.NotEqual( Guid.Empty, resp.Content );
+        Assert.NotEqual( broadcastId, resp.Content );
+    }
+
+
+    /// <summary/>
+    [Fact]
     public async Task BroadcastList()
     {
         var resp = await _resend.BroadcastListAsync();

--- a/tools/Resend.ApiServer/Controllers/BroadcastController.cs
+++ b/tools/Resend.ApiServer/Controllers/BroadcastController.cs
@@ -91,6 +91,21 @@ public class BroadcastController : ControllerBase
     }
 
 
+    /// <summary />
+    [HttpPost]
+    [Route( "broadcasts/{broadcastId}/duplicate" )]
+    public ObjectId BroadcastDuplicate( [FromRoute] Guid broadcastId )
+    {
+        _logger.LogDebug( "BroadcastDuplicate" );
+
+        return new ObjectId()
+        {
+            Object = "broadcast",
+            Id = Guid.NewGuid(),
+        };
+    }
+
+
     /// <summary>
     /// The fake server has no persisted state, so the well-known empty id doubles as the
     /// "broadcast not found" fixture for tests, mirroring <see cref="EmailController.EmailShare"/>.

--- a/tools/Resend.Cli/Broadcast/BroadcastDuplicateCommand.cs
+++ b/tools/Resend.Cli/Broadcast/BroadcastDuplicateCommand.cs
@@ -1,0 +1,34 @@
+using McMaster.Extensions.CommandLineUtils;
+using System.ComponentModel.DataAnnotations;
+
+namespace Resend.Cli.Broadcast;
+
+/// <summary />
+[Command( "duplicate", Description = "Duplicate a broadcast" )]
+public class BroadcastDuplicateCommand
+{
+    private readonly IResend _resend;
+
+
+    /// <summary />
+    [Argument( 0, Description = "Broadcast identifier" )]
+    [Required]
+    public Guid? BroadcastId { get; set; }
+
+
+    /// <summary />
+    public BroadcastDuplicateCommand( IResend resend )
+    {
+        _resend = resend;
+    }
+
+
+    /// <summary />
+    public async Task<int> OnExecuteAsync()
+    {
+        var res = await _resend.BroadcastDuplicateAsync( this.BroadcastId!.Value );
+        Console.WriteLine( res.Content );
+
+        return 0;
+    }
+}

--- a/tools/Resend.Cli/BroadcastCommand.cs
+++ b/tools/Resend.Cli/BroadcastCommand.cs
@@ -8,6 +8,7 @@ namespace Resend.Cli;
 [Subcommand( typeof( Broadcast.BroadcastCancelCommand ) )]
 [Subcommand( typeof( Broadcast.BroadcastClickedLinksCommand ) )]
 [Subcommand( typeof( Broadcast.BroadcastDeleteCommand ) )]
+[Subcommand( typeof( Broadcast.BroadcastDuplicateCommand ) )]
 [Subcommand( typeof( Broadcast.BroadcastListCommand ) )]
 [Subcommand( typeof( Broadcast.BroadcastListRecipientsCommand ) )]
 [Subcommand( typeof( Broadcast.BroadcastRetrieveCommand ))]


### PR DESCRIPTION
This ports `resend.broadcasts.duplicate(id)` from the Node SDK as `BroadcastDuplicateAsync`, for the `POST /broadcasts/{id}/duplicate` endpoint added in resend/resend-openapi#115, plus a `broadcast duplicate` command in the deprecated CLI. It is a hand port, since the `tools/dotnet-gen` generator refuses Broadcasts. The release carries 0.18.0.

Claude called the new method against staging from a scratch console app and ran the CLI command once, then deleted both copies with httpie. The test keeps `Assert.NotEqual( broadcastId, resp.Content )` on purpose: it is the assertion that separates a duplicate from an update against the fake server.

```
Success:   True
Source id: e6bd3843-3cc7-4c0d-b7fd-e01cbb514a16
New id:    b696b590-6c4c-43b1-b45d-9cbcf9eb6912
Differs:   True
```

```
GET /broadcasts/b696b590-6c4c-43b1-b45d-9cbcf9eb6912 -> HTTP/1.1 200 OK
{"object":"broadcast","id":"b696b590-6c4c-43b1-b45d-9cbcf9eb6912","name":"Untitled (copy)","status":"draft",...}

DELETE /broadcasts/b696b590-6c4c-43b1-b45d-9cbcf9eb6912 -> HTTP/1.1 200 OK
{"object":"broadcast","id":"b696b590-6c4c-43b1-b45d-9cbcf9eb6912","deleted":true}
```

```
$ resend broadcast duplicate e6bd3843-3cc7-4c0d-b7fd-e01cbb514a16
01b8fc5c-3023-40bf-b641-324325ee1a77

DELETE /broadcasts/01b8fc5c-3023-40bf-b641-324325ee1a77 -> HTTP/1.1 200 OK
{"object":"broadcast","id":"01b8fc5c-3023-40bf-b641-324325ee1a77","deleted":true}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the ability to duplicate a broadcast through the .NET SDK and the deprecated CLI, porting the Node SDK's `resend.broadcasts.duplicate(id)`.

**Changes**
- Adds `BroadcastDuplicateAsync` to `IResend` and `ResendClient`, calling `POST /broadcasts/{id}/duplicate`.
- Adds the `broadcast duplicate` CLI command.
- Adds a fake-server route and a test asserting the duplicate ID differs from the source.
- Bumps the package version to 0.18.0.

<sup>Written for commit c8c63325c603fc8d089c90c04ac700eeb810115a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-dotnet/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

